### PR TITLE
ml.read() loads node/edge data, loads booleans, negative ints, enquoted ints (for big vals), and escapes xml entities

### DIFF
--- a/src/zen/io/gml.py
+++ b/src/zen/io/gml.py
@@ -17,18 +17,20 @@ from zen.graph import Graph
 from zen.digraph import DiGraph
 from zen.bipartite import BipartiteGraph
 import os
+import cgi
+import re
 
 __all__ = ['read','write']
 
 STR_TOK = 'STRING'
 INT_TOK = 'INT'
 FLOAT_TOK = 'FLOAT'
+BOOL_TOK = "BOOL"
 ID_TOK = 'ID'
 SLIST_TOK = '['
 ELIST_TOK = ']'
 
-def write(G,filename):
-	# Like this?...
+def write(G,filename, **kwargs):
 	"""
 	Writes graph to file using Graph Modeling Language (gml).  Node / Edge / Graph objects, if not None, are stored in the `name` 
 	attribute, and are restricted to numeric (but not complex), string, and boolean data types, otherwise an exception is raised.  
@@ -43,14 +45,40 @@ def write(G,filename):
 			written to file. Hypergraphs are not supported.
 	
 		* ``filename`` (str): Absolute path for the file to be written.
-	
+	**KwArgs**
+		* ``write-data`` (bool | (bool, bool)): If 2-tuple of booleans supplied, first indicates whether to write out node data
+				second whether to write out edge data.  If bool provided, it is applied for both node and edge data.
+		* ``use-zen-data`` (bool | (bool, bool)): Indicates whether to write out If 2-tuple of booleans supplied, first indicates whether to write out node data
+						second whether to write out edge data.  If bool provided, it is applied for both node and edge data. 
 	**Returns**:
-		None
+		* None
 	"""
 	
+	# Decide whether to write node and edge data
+	if 'write_data' in kwargs:
+		if type(kwargs['write_data']) == tuple:
+			write_node_data, write_edge_data = kwargs['write_data']
+		elif type(kwargs['write_data']) == bool:
+			write_node_data = write_edge_data = kwargs['write_data']
+		# else raise zenException?  Not sure how far to take verification...
+			
+	else:
+		write_node_data, write_edge_data = True, True
+	
+	# Decide *how* to write node / edge data to file
+	if 'use_zen_data' in kwargs:
+		if type(kwargs['use_zen_data']) == tuple:
+		 	use_node_zen_data, use_edge_zen_data = kwargs['use_zen_data']
+		else:
+			use_node_zen_data = use_edge_zen_data = kwargs['use_zen_data']
+		#else raise zenException?s
+		
+	else: 
+		use_node_zen_data = use_edge_zen_data = True
+		
 	fh = open(filename, 'w')
 	fh.write('# This is a graph object in gml file format\n')
-	fh.write('# produced by the zen graph library\n')
+	fh.write('# produced by the zen graph library\n\n')
 	fh.write('graph [\n')
 	
 	if G.is_directed():
@@ -58,7 +86,7 @@ def write(G,filename):
 	else:
 		fh.write('\tdirected 0\n')
 	
-	if type(G) == BipartiteGraph:		# to allow recovering proper graph type
+	if type(G) == BipartiteGraph:
 		fh.write('\tbipartite 1\n')
 	else:
 		fh.write('\tbipartite 0\n')		
@@ -68,14 +96,16 @@ def write(G,filename):
 		fh.write('\t\tid ' + str(nidx) + '\n')
 		
 		if nobj != None:
-			fh.write('\t\tname ' + write_obj(nobj) + '\n')
+			fh.write(format_zen_data(nobj, 'name', 2))
 		
-		if ndata != None:
-			# E: Let's think about this.  Hard to know exactly what the right thing to do is.  gml.read() puts all the properties of the
-			# node into a single dictionary that is the node data.  However, as you've noted, I think gml.read(gml.write()) should return the 
-			# same object - so what should be the proper rule.  Thoughts?  Email me about this ... so we don't have a discussion via git :)
-			fh.write('\t\tzen_data ' + write_obj(ndata) + '\n')
-		
+		if ndata != None and write_node_data:
+			if use_node_zen_data:
+				fh.write(format_zen_data(ndata, 'zenData', 2))
+			
+			else:	# expects zenData to be dict
+				for key, val in ndata.items():
+					fh.write(format_zen_data(val, key, 2))
+			
 		fh.write('\t]\n')
 	
 	# iterate over edges
@@ -83,55 +113,145 @@ def write(G,filename):
 		fh.write('\tedge [\n')
 		fh.write('\t\tsource ' + str(G.endpoints_(eidx)[0]) + '\n')	# for digraphs, assumes endpoints order [source, target]
 		fh.write('\t\ttarget ' + str(G.endpoints_(eidx)[1]) + '\n')
-		if edata != None:
-			fh.write('\t\tzen_data ' + write_obj(edata) + '\n')
-		
 		fh.write('\t\tweight ' + str(weight) + '\n')
+		
+		if edata != None and write_edge_data:
+			if use_edge_zen_data:
+				fh.write(format_zen_data(edata, 'zenData', 2))
+			
+			else:	#expects zenData to be dict
+				for key, val in edata.items():
+					fh.write(format_zen_data(val, key, 2))
+		
 		fh.write('\t]\n')
 	
 	fh.write(']\n')
 	fh.close()
 
-def write_obj(obj):
-	supported_objs = set([str, bool, int, long, float])
-	if (type(obj) not in supported_objs) and (obj != None):
-		raise ZenException('gml.write() supports node / edge objects: bool, str, Numeric (not complex), None')
 	
-	if type(obj) == bool:
-		obj = str(obj)
+def format_zen_data(data, keyname, tab_depth=0):
+	"""
+	Reformats supplied data to use gml.  Enforces restrictions on the types of data that can be written to gml.
 	
-	if type(obj) == int or type(obj) == long:		
-		if obj > 2147483647 or obj < -2147483648:	# gml specifies integers larger than 32 bit signed must be strings
-			obj = str(obj)
-		
-	if type(obj) == str: # note bool and big numerics go in here too
-		if '"' in obj:
-			raise ZenException('gml values cannot contain nested double quotes')
-		obj = '"' + obj + '"'
-	
-	# TODO: how will gml.read() know when to evaluate a string as bool or numeric?  Just adopt policy that 
-	# strings which look like numbers / bool will be eval'd as such?
-	
-	return str(obj) # additional application of str() to strings has no effect, needed for other types
+	**Args**
+		* data (bool | int | long | float | str | dict | list): object to be written in gml
+		* key (str): key to be used in gml.  Needed here because in gml lists are made by repeating the key in front of each value.
+		* tab_depth (int): number of tab characters to add to the beginning of each line for nice formatting.
 
+	**Returns**
+		* formatted_data (str): gml representation of data
+	"""
 	
+	formatted_data = ''
+	tabs = '\t' * tab_depth
+	if re.search('[^a-zA-Z0-9]', keyname):
+		raise ZenException('gml supports only characters from [a-zA-Z0-9] in keys')
 	
+	if type(data) == bool: # booleans are recorded as strings.  They have to be detected on read
+		formatted_data += tabs + keyname + ' "' + str(data) + '"\n'
+	
+	elif type(data) == int or type(data) == long:		
+		if data > 2147483647 or data < -2147483648:	# gml specifies integers larger than 32 bit signed must be strings
+			formatted_data += tabs + keyname + ' "' + str(data) + '"\n'
+		else:
+			formatted_data += tabs + keyname + ' ' + str(data) + '\n'
+
+	elif type(data) == float:
+		formatted_data += tabs + keyname + ' ' + str(data) + '\n'
+		
+	elif type(data) == str:
+		data = cgi.escape(data, quote=True)		# escapes xml special characters and quotes
+		data = data.decode('utf-8').encode('iso_8859_1', 'xmlcharrefreplace')		# escapes non-ISO-8859-1 chars
+		formatted_data += tabs + keyname + ' "' + data.decode('utf-8').encode('iso_8859_1', 'xmlcharrefreplace') + '"\n'
+
+	elif type(data) == list:		# this may seem odd, because gml uses repeated keys to indicate a list
+		for val in data:
+			formatted_data += format_zen_data(val, keyname, tab_depth)
+	
+	elif type(data) == dict:
+		formatted_data += tabs + keyname + ' [\n'
+		for key, val in data.items():
+			formatted_data += format_zen_data(val, key, tab_depth + 1)
+		formatted_data += tabs + ']\n'
+	
+	else:
+		raise ZenException('gml.write() supports objects: bool, str, Numeric (not complex), None, and dicts or lists containing only such types (nesting allowed)')
+	
+	return formatted_data
+	
+def decode_xml_entities(s):
+	# D: I read through encoding info and couldn't find the functions to undo the substitution of xml entities
+	# so I just wrote it.  It took me a lot less time than I spent searching... go figure
+	s_decode = u''
+	
+	i = 0
+	while  i < len(s):
+
+		if s[i] == '&':
+			i = i+1
+			code_point = ''
+			
+			while s[i] != ';':
+				code_point += s[i]
+				i = i+1
+			
+			if code_point == 'quot':
+				s_decode += '"'
+			elif code_point == 'lt':
+				s_decode += '<'
+			elif code_point == 'gt':
+				s_decode += '>'
+			elif code_point == 'amp':
+				s_decode += '&'
+			elif code_point[:1] == '#':
+				s_decode += unichr(int(code_point[1:]))
+			else:
+				raise ZenException, 'Cannot recognize the xml entity &%s;' % code_point
+			
+			i = i+1
+
+		else:
+			s_decode += s[i]
+			i = i+1
+
+	return s_decode.encode('utf-8')
+			
+		
 def add_token_metadata(token,in_str,lineno):
 	
 	if in_str:
-		return (token,STR_TOK,lineno)
+		if re.match("[-+0-9.]", token[:1]): 	# looks like a number, try it
+			try:
+				token = int(token)
+				return (token, INT_TOK, lineno)
+			except ValueError:
+				token = float(token)
+				return (token, FLOAT_TOK, lineno)
+			except ValueError:
+				return (token, STR_TOK, lineno)
 		
+		elif token == "True":		# treat as boolean
+			token = True
+			return (token, BOOL_TOK, lineno)
+
+		elif token == "False":
+			token = False
+			return (token, BOOL_TOK, lineno)
+			
+		else:	
+			return (token,STR_TOK,lineno)
+				
 	if token == SLIST_TOK:
 		return (token,SLIST_TOK,lineno)
 	elif token == ELIST_TOK:
 		return (token,ELIST_TOK,lineno)
 	
-	if token.isdigit():
+	if token.isdigit(): # TEST: I don't think this will handle leading '+' or '-'...
 		return (int(token),INT_TOK,lineno)
 	else:
 		try: # see if it's a float
 			return (float(token),FLOAT_TOK,lineno)
-		except ValueError:
+		except ValueError: # Keyname tokens are unquoted strings
 			return (token,ID_TOK,lineno)
 
 def tokenize(fh):
@@ -201,7 +321,10 @@ def parse_value(tokens,i):
 	
 	val,ttok,lineno = tokens[i]
 	
-	if ttok == STR_TOK or ttok == INT_TOK or ttok== FLOAT_TOK:
+	if ttok == INT_TOK or ttok == FLOAT_TOK or ttok == BOOL_TOK:
+		return i+1,val
+	elif ttok == STR_TOK: # restore characters escaped by xmlcharrefreplace (need to use a unicode, UTF-8 string)
+		val = decode_xml_entities(val)
 		return i+1,val
 	elif ttok == SLIST_TOK:
 		return parse_list(tokens,i+1)
@@ -245,6 +368,8 @@ def build_graph(graph_data,weight_fxn):
 	is_directed = False
 	if 'directed' in graph_data:
 		is_directed = graph_data['directed'] == 1
+	
+	# TODO detect if graphs are bipartite and support that
 		
 	G = None
 	if is_directed:
@@ -260,37 +385,54 @@ def build_graph(graph_data,weight_fxn):
 		if type(nodes) != list:
 			raise ZenException, 'The node attribute of a graph must be a list'
 			
-		for node in nodes:
-			
-			# enforce types on standard attributes
-			if 'name' in node:
-				if type(node['name']) != str:
-					raise ZenException, 'Node name attribute must be a string (node = %s)' % str(node)
-			if 'label' in node:
-				if type(node['label']) != str:
-					raise ZenException, 'Node label attribute must be a string (node = %s)' % str(node)
-			
-			# get the node index
-			node_idx = None
+		for node in nodes:	
+			# node must have an 'id'
 			if 'id' not in node:
 				raise ZenException, 'Node is missing the id attribute (node = %s)' % str(node)
 			node_idx = node['id']
-			if type(node_idx) != int or node_idx < 0:
-				raise ZenException, 'Node id attribute must be a positive integer (node = %s)' % str(node)
 				
-			# get the node object
-			node_obj = node_idx
-			if 'name' in node:
-				node_obj = node['name']
-			elif 'label' in node:
-				node_obj = node['label']
-				if type(node_obj) != str:
-					raise ZenException, 'Node label attribute must be a string (node = %s)' % str(node)
+			# collect and verify all the node properties
+			standard_keys = set(['id', 'name', 'zenData'])
+			node_data = {}
+			node_obj = None
+			zen_data = None
+			for key, val in node.items():
+				if key == 'id':
+					node_idx = val
+					if type(val) != int or val < 0:
+						raise ZenException, 'Node id attribute must be a positive integer (node = %s)' % str(node)
+
+				elif key == 'name':
+					node_obj = val
+					if type(val) != str: # enforce types on standard attributes
+						raise ZenException, 'Node name attribute must be a string (node = %s)' % str(node)
+
+				elif key == 'label':
+					if node_obj is None: 	# give preference to 'name' as source of node_obj
+						node_obj = val
+					if type(val) != str:
+						raise ZenException, 'Node label attribute must be a string (node = %s)' % str(node)
+
+				elif key == 'zenData':
+					zen_data = val
+				
+				else:	
+					node_data[key] = val 	# node_data is dict of all other attributes
+
+			# if zenData is only other attribute aside from those handled above _set_ to node_data else _append_
+			if zen_data is not None:
+				if len(node_data) == 0:
+					node_data = zen_data
+				else:
+					node_data['zenData'] = zen_data
+			
+			elif len(node_data) == 0:
+				node_data = None
 								
 			if is_directed:
-				G.add_node_x(node_idx,G.edge_list_capacity,G.edge_list_capacity,node_obj,node)
+				G.add_node_x(node_idx,G.edge_list_capacity,G.edge_list_capacity,node_obj,node_data)
 			else:
-				G.add_node_x(node_idx,G.edge_list_capacity,node_obj,node)
+				G.add_node_x(node_idx,G.edge_list_capacity,node_obj,node_data)
 			
 	# add edges
 	if 'edge' in graph_data:
@@ -300,36 +442,65 @@ def build_graph(graph_data,weight_fxn):
 		
 		for edge in edges:
 			
-			# enforce typed attributes
-			edge_idx = None
-			if 'id' in edge:
-				edge_idx = edge['id']
-				if type(edge_idx) != int:
-					raise ZenException, 'Edge id attribute must be a positive integer (edge = %s)' % str(edge)
-			
 			# make sure source and target are specified
 			source = None
 			target = None
 			if 'source' not in edge:
 				raise ZenException, 'Edge is missing the source attribute (edge = %s)' % str(edge)
-			source = edge['source']
-			if type(source) != int or source < 0:
-				raise ZenException, 'Edge source attribute must be a positive integer (edge = %s)' % str(edge)
 			
 			if 'target' not in edge:
 				raise ZenException, 'Edge is missing the target attribute (edge = %s)' % str(edge)
-			target = edge['target']
-			if type(target) != int or source < 0:
-				raise ZenException, 'Edge target attribute must be a positive integer (edge = %s)' % str(edge)
-				
+			
 			weight = 1
+			edge_idx = None
+			zen_data = None
+			edge_data = {}
+			
+			for key, val in edge.items():
+				if key == 'id':
+					edge_idx = val
+					if type(val) != int:
+						raise ZenException, 'Edge id attribute must be a positive integer (edge = %s)' % str(edge)
+				
+				elif key == 'source':
+					source = val
+					if type(val) != int or val < 0:
+						raise ZenException, 'Edge source attribute must be a positive integer (edge = %s)' % str(edge)
+				
+				elif key == 'target':
+					target = val
+					if type(val) != int or val < 0:
+						raise ZenException, 'Edge target attribute must be a positive integer (edge = %s)' % str(edge)
+				
+				elif key == 'weight':
+					weight = float(val)
+				
+				elif key == 'zenData':
+					zen_data = val
+			
+				else: 
+					edge_data[key] = val 	# edge_data is dict of all other attributes
+			
+			# give precedence to a weight-getting function if provided
 			if weight_fxn != None:
 				weight = weight_fxn(edge)
 			
+			# if zenData is only other attribute aside from those handled above _set_ to edge_data else _append_
+			if zen_data is not None:
+				if len(edge_data) == 0:
+					edge_data = zen_data
+				else:
+					edge_data['zenData'] = zen_data
+
+			elif len(edge_data) == 0:
+				edge_data = None;
+		
 			if edge_idx != None:
-				G.add_edge_x(edge_idx,source,target,edge,weight)
+				G.add_edge_x(edge_idx,source,target,edge_data,weight)
 			else:
-				G.add_edge_(source,target,edge,weight)
+				G.add_edge_(source,target,edge_data,weight)
+			
+			
 				
 	return G
 				

--- a/src/zen/tests/test4.gml
+++ b/src/zen/tests/test4.gml
@@ -1,0 +1,44 @@
+# This is a graph object in gml file format
+# produced by the zen graph library
+
+graph [
+	directed 0
+	bipartite 0
+	node [
+		id 0
+		name "A"
+		zenData [
+			label "soft"
+			attr1 "one"
+			attr2 "two"
+		]
+	]
+	node [
+		id 1
+		name "B"
+		label "soft"
+		attr1 "one"
+		attr2 "two"
+	]
+	edge [
+		id 0
+		source 0
+		target 1
+		weight 1.0
+		zenData [
+			label "soft"
+			attr1 "one"
+			attr2 "two"
+		]
+	]
+	edge [
+		id 1
+		source 1
+		target 2
+		weight 1.0
+		zenData "included if other data present"
+		label "soft"
+		attr1 "one"
+		attr2 "two"
+	]
+]


### PR DESCRIPTION
the read() and write() functions for gml files now do what we discussed.  There is a _slight_ deviation however, because I think this is what you actually want, but if not it's easy to revert:

Recall that read() looks for node attributes named 'id',  and 'name', and handles these specially (puts them in node_idx and node_obj).  For edges, it looks for 'id', 'weight', 'source', and 'target', and of course these have their special places in the Graph object too.

Now any other attributes that appear aside from those mentioned are packaged into a dictionary which gets aside to the node/edge_data.  This is different from what we discussed, wherein _all_ attributes would get packed except for 'weight' in the case of edges... but this would mean that a read / write operation would not leave the gml unchanged.  The way I've done it, it would.  This only applies when zenData is not being used, and the other conditional behaviours we discussed are as discussed.

I can show you what I mean on a whiteboard some time if you want.
