### PR TITLE
Improved setup.py and potentially fixed issue 6

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,4 +4,22 @@ Zen is a Python library that provides a high-speed, easy-to-use API for analysin
 
 Official site: http://zen.networkdynamics.org/
 
+## Installation
+
+To install zenlib do the following:
+
+- ``git clone`` the repository
+- Install: distribute, cython>=0.14, numpy>=1.6.1
+- ``cd`` to ``src/`` and run ``python setup.py install``
+
+Here is an example of the installation process using [virtualenv](http://www.virtualenv.org/en/latest/index.html) for
+convenience:
+
+    git clone https://github.com/networkdynamics/zenlib.git
+    virtualenv --distribute zenlibenv
+    (zenlibenv) pip install cython
+    (zenlibenv) pip install numpy
+    (zenlibenv) cd zenlib/src/
+    (zenlibenv) python setup.py install
+
 License: BSD

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,5 +1,8 @@
-from distutils.core import setup
-#from setuptools import setup
+try:
+	from setuptools import setup
+except ImportError:
+	#This should not be the case though
+	from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
 import os.path
@@ -28,15 +31,15 @@ ext_modules = [	Extension('zen.graph', ['zen/graph.pyx'], include_dirs=[numpy_in
 				Extension('zen.algorithms.centrality', ['zen/algorithms/centrality.pyx'], include_dirs=[numpy_include_dir]),
 				Extension('zen.layout.spring_layout', ['zen/layout/spring_layout.pyx'], include_dirs=[numpy_include_dir]),
 				Extension('zen.layout.random_layout', ['zen/layout/random_layout.pyx'], include_dirs=[numpy_include_dir]),
-				Extension('zen.layout.forceatlas_layout', ['zen/layout/forceatlas_layout.pyx'], include_dirs=[numpy_include_dir]),				
-				Extension('zen.layout.fruchtermanreingold_layout', ['zen/layout/fruchtermanreingold_layout.pyx'], include_dirs=[numpy_include_dir]),								
+				Extension('zen.layout.forceatlas_layout', ['zen/layout/forceatlas_layout.pyx'], include_dirs=[numpy_include_dir]),
+				Extension('zen.layout.fruchtermanreingold_layout', ['zen/layout/fruchtermanreingold_layout.pyx'], include_dirs=[numpy_include_dir]),
 				Extension('zen.algorithms.shortest_path', ['zen/algorithms/shortest_path.pyx'], include_dirs=[numpy_include_dir, fiboheap_include_dir]),
 				Extension('zen.algorithms.properties', ['zen/algorithms/properties.pyx'], include_dirs=[numpy_include_dir]),
-                Extension('zen.algorithms.modularity', ['zen/algorithms/modularity.pyx'], include_dirs=[numpy_include_dir]),
+				Extension('zen.algorithms.modularity', ['zen/algorithms/modularity.pyx'], include_dirs=[numpy_include_dir]),
 				Extension('zen.algorithms.spanning', ['zen/algorithms/spanning.pyx'], include_dirs=[numpy_include_dir, fiboheap_include_dir]),
 				Extension('zen.algorithms.matching', ['zen/algorithms/matching.pyx'], include_dirs=[numpy_include_dir]),
 				Extension('zen.generating.rgm', ['zen/generating/rgm.pyx'], include_dirs=[numpy_include_dir]),
-                Extension('zen.algorithms.community.label_propagation', ['zen/algorithms/community/label_propagation.pyx'], include_dirs=[numpy_include_dir])]
+				Extension('zen.algorithms.community.label_propagation', ['zen/algorithms/community/label_propagation.pyx'], include_dirs=[numpy_include_dir])]
 
 
 setup(
@@ -57,20 +60,20 @@ setup(
 					'zen.layout' : ['*.pxd'],
 					'zen.tests' : ['*.pxd','*.scn','*.elist','*.helist','*.rdot', '*.memlist', '*.gml'],
 					'zen.util' : ['*.pxd'],
-					'zen.data' : ['*.scn','*.gml'] }#,
-	
+					'zen.data' : ['*.scn','*.gml'] },
+
 	# # dependencies
-	# setup_requires = ['cython>=0.14'],
-	# install_requires = ['numpy>=1.6.1','matplotlib>=1.0.1'],
-	# 
+	setup_requires = ['distribute','cython>=0.14'],
+	install_requires = ['numpy>=1.6.1','matplotlib>=1.0.1', 'networkx'],
+	#
 	# # testing suite
 	# test_suite = 'zen.test',
-	# 
+	#
 	# # project metadata
-	# author = 'Derek Ruths',
-	# author_email = 'druths@networkdynamics.org',
-	# description = 'Zen is a high-performance, easy-to-use network library developed specifically for Python.',
-	# license = 'BSD',
-	# url = 'http://zen.networkdynamics.org',
-	# download_url = 'https://github.com/networkdynamics/zenlib'
+	author = 'Derek Ruths',
+	author_email = 'druths@networkdynamics.org',
+	description = 'Zen is a high-performance, easy-to-use network library developed specifically for Python.',
+	license = 'BSD',
+	url = 'http://zen.networkdynamics.org',
+	download_url = 'https://github.com/networkdynamics/zenlib'
 )


### PR DESCRIPTION
Hello,

Zenlib still had some issues building on Ubuntu so I worked on the setup.py script (see below) and added installation instructions in the repository's readme.md so that interested parties can install the library quickly.

The original issue: zenlib depends on networkx but networkx wasn't listed in the install instructions nor was `setup.py` fetching any dependencies. I hypothesize that the commenting out of the `install_requires` was originally due to setuptools and cython's incompatibility which led to the use of `distutils.core` as a stop-gap. To fix this I've clearly indicated the dependency on [distribute](http://pythonhosted.org/distribute/http://pythonhosted.org/distribute/) which fixes this [issue](https://bitbucket.org/tarek/distribute/issue/195). Dependencies can now be listed again! It seems like distribute is [getting traction](http://guide.python-distribute.org/installation.html) so I don't think it is such a far-fetched solution.

I also believe this fixes #6 as the problem there was due to missing .c files which would not have been built by the `setup.py` script using regular setuptools.

Hopefully this makes sense and helps make zenlib easier to install.
