### PR TITLE
Fixed DiGraph.edges() call with a nobj

### DIFF
--- a/src/zen/digraph.pyx
+++ b/src/zen/digraph.pyx
@@ -29,7 +29,7 @@ cdef inline int imax(int a, int b):
 		return b
 	else:
 		return a
-		
+
 cdef inline int imin(int a, int b):
 	if a < b:
 		return a
@@ -41,19 +41,19 @@ This data structure contains node info (in C-struct format) for fast array-based
 
 When a node info entry is part of the free node list, the indegree points to the next
 entry in the list and the in_capacity points to the previous entry in the list.
-"""		
+"""
 cdef struct NodeInfo:
 	# This data structure contains node info (in C-struct format) for fast array-based lookup.
 	bint exists
-	
+
 	int indegree # The number of entries in the inelist that are in use
 	int* inelist
 	int in_capacity  # The length of the inelist
-	
+
 	int outdegree # the number of entries in outelist that are in use
 	int* outelist
 	int out_capacity # the length of outelist
-	
+
 cdef int sizeof_NodeInfo = sizeof(NodeInfo)
 
 """
@@ -65,7 +65,7 @@ cdef struct EdgeInfo:
 	int src # Node idx for the source of the edge
 	int tgt # Node idx for the tgt of the edge
 	double weight
-	
+
 cdef int sizeof_EdgeInfo = sizeof(EdgeInfo)
 
 """
@@ -79,9 +79,9 @@ CURRENT_PICKLE_VERSION = 1.0
 cdef class DiGraph:
 	"""
 	This class provides a highly-optimized implementation of a `directed graph <http://en.wikipedia.org/wiki/Directed_graph>`_.  Duplicate edges are not allowed.
-	
+
 	Public properties include:
-	
+
 		* ``max_node_index`` (int): the largest node index currently in use
 		* ``max_edge_index`` (int): the largest edge index currently in use
 		* ``edge_list_capacity`` (int): the initial number of edge positions that will be allocated in a newly created node's in and out edge lists.
@@ -89,32 +89,32 @@ cdef class DiGraph:
 		* ``edge_grow_factor`` (int): the multiple by which the edge storage array will grow when its capacity is exceeded.
 		* ``edge_list_grow_factor`` (int): the multiple by which the a node's in/out edge list storage array will grow when its capacity is exceeded.
 	"""
-	
+
 	def __init__(DiGraph self,**kwargs):
 		"""
 		Create a new :py:class:`DiGraph` object.
-		
+
 		**Keyword Args**:
-		
+
 		  * ``node_capacity [=100]`` (int): the initial number of nodes this graph has space to hold.
 		  * ``edge_capacity [=100]`` (int): the initial number of edges this graph has space to hold.
 		  * ``edge_list_capacity [=5]`` (int): the initial number of edges that each node is allocated space for initially.
-		
+
 		"""
 		node_capacity = kwargs.pop('node_capacity',100)
 		edge_capacity = kwargs.pop('edge_capacity',100)
 		edge_list_capacity = kwargs.pop('edge_list_capacity',5)
-		
+
 		cdef int i
-		
+
 		self.first_free_node = -1
 		self.first_free_edge = -1
-		
+
 		self.num_changes = 0
 		self.node_grow_factor = 1.5
 		self.edge_list_grow_factor = 1.5
 		self.edge_grow_factor = 1.5
-	
+
 		self.num_nodes = 0
 		self.node_capacity = node_capacity
 		self.next_node_idx = 0
@@ -125,7 +125,7 @@ cdef class DiGraph:
 		self.node_obj_lookup = {}
 		self.node_data_lookup = {}
 		self.node_idx_lookup = {}
-		
+
 		self.num_edges = 0
 		self.edge_capacity = edge_capacity
 		self.next_edge_idx = 0
@@ -134,9 +134,9 @@ cdef class DiGraph:
 		for i in range(self.edge_capacity):
 			self.edge_info[i].exists = False
 		self.edge_data_lookup = {}
-		
+
 		self.edge_list_capacity = edge_list_capacity
-	
+
 	def __dealloc__(DiGraph self):
 		cdef int i
 		# deallocate all node data (node_info)
@@ -145,15 +145,15 @@ cdef class DiGraph:
 				stdlib.free(self.node_info[i].inelist)
 				stdlib.free(self.node_info[i].outelist)
 		stdlib.free(self.node_info)
-		
+
 		# deallocate all edge data (edge_info)
 		stdlib.free(self.edge_info)
-	
+
 	def __reduce__(self):
 		return (DiGraph,tuple(),self.__getstate__())
 
 	def __getstate__(self):
-		
+
 		state = {'PICKLE_VERSION':1.0}
 
 		# store global details
@@ -162,21 +162,21 @@ cdef class DiGraph:
 		# store all node details
 		state['num_nodes'] = self.num_nodes
 		state['node_capacity'] = self.node_capacity
-		state['node_grow_factor'] = self.node_grow_factor		
+		state['node_grow_factor'] = self.node_grow_factor
 		state['next_node_idx'] = self.next_node_idx
-		state['first_free_node'] = self.first_free_node		
+		state['first_free_node'] = self.first_free_node
 		state['node_obj_lookup'] = self.node_obj_lookup
 		state['node_data_lookup'] = self.node_data_lookup
 		state['node_idx_lookup'] = self.node_idx_lookup
 		state['edge_list_capacity'] = self.edge_list_capacity
-		state['edge_list_grow_factor'] = self.edge_list_grow_factor		
+		state['edge_list_grow_factor'] = self.edge_list_grow_factor
 
 		# store node_info
 		node_info = []
 		for i in range(self.node_capacity):
 			pickle_entry = None
 
-			if self.node_info[i].exists is not 0:		
+			if self.node_info[i].exists is not 0:
 				pickle_entry = (bool(self.node_info[i].exists),
 								self.node_info[i].indegree,
 								self.node_info[i].in_capacity,
@@ -196,7 +196,7 @@ cdef class DiGraph:
 		# store all edge details
 		state['num_edges'] = self.num_edges
 		state['edge_capacity'] = self.edge_capacity
-		state['edge_grow_factor'] = self.edge_grow_factor		
+		state['edge_grow_factor'] = self.edge_grow_factor
 		state['next_edge_idx'] = self.next_edge_idx
 		state['first_free_edge'] = self.first_free_edge
 		state['edge_data_lookup'] = self.edge_data_lookup
@@ -245,7 +245,7 @@ cdef class DiGraph:
 				self.node_info[i].inelist = <int*> stdlib.malloc(sizeof(int) * in_capacity)
 				for j,eidx in enumerate(inelist):
 					self.node_info[i].inelist[j] = eidx
-					
+
 				self.node_info[i].outdegree = outdegree
 				self.node_info[i].out_capacity = out_capacity
 
@@ -258,7 +258,7 @@ cdef class DiGraph:
 				self.node_info[i].exists = exists
 				self.node_info[i].indegree = indegree
 				self.node_info[i].in_capacity = in_capacity
-				
+
 				self.node_info[i].outdegree = -1
 				self.node_info[i].out_capacity = -1
 
@@ -275,32 +275,32 @@ cdef class DiGraph:
 		self.max_edge_idx = -1
 		for i,entry in enumerate(state['edge_info']):
 			exists,src,tgt,weight = entry
-			
+
 			if exists == 1:
 				self.max_edge_idx = i
-				
+
 			self.edge_info[i].exists = exists
 			self.edge_info[i].src = src
 			self.edge_info[i].tgt = tgt
 			self.edge_info[i].weight = weight
 
 		return
-	
-	def validate(self,**kwargs):		
+
+	def validate(self,**kwargs):
 		"""
 		Checks whether the graph structure is valid.
-		
-		This method inspects various invariants and conditions that should be present 
+
+		This method inspects various invariants and conditions that should be present
 		in order for the graph structure to be correct.  If any conditions are
 		broken, an exception will be raised immediately.
 
 		**KwArgs**:
-			
+
 			* ``verbose [=False]`` (boolean): print debugging information out before each condition check
-		
-		**Raises**: 
+
+		**Raises**:
 			``AssertionError``: if a condition isn't satisfied.
-		
+
 		"""
 		verbose = kwargs.pop('verbose',False)
 
@@ -370,107 +370,107 @@ cdef class DiGraph:
 
 		#####
 		# Check edges
-		
+
 		# self.next_edge_idx < self.edge_capacity
 		if verbose:
 			print 'checking if self.next_edge_idx < self.edge_capacity'
-		
+
 		assert self.next_edge_idx <= self.edge_capacity, 'self.next_edge_idx > self.edge_capacity (%d,%d)' % (self.next_edge_idx,self.edge_capacity)
-		
+
 		# self.max_edge_idx < self.next_edge_idx
 		if verbose:
 			print 'checking if self.max_edge_idx < self.next_edge_idx'
-		
+
 		assert self.max_edge_idx < self.next_edge_idx, 'self.max_edge_idx >= self.next_edge_idx (%d,%d)' % (self.max_edge_idx,self.next_edge_idx)
-		
+
 		# there should be no other valid edges beyond self.max_edge_idx
 		if verbose:
 			print 'checking if no valid edges exist beyond self.max_edge_idx'
-		
+
 		for i in range(self.max_edge_idx+1,self.edge_capacity):
 			assert not self.edge_info[i].exists, 'self.edge_info[%d] exists, but is beyond self.max_edge_idx (= %d)' % (i,self.max_edge_idx)
-		
+
 		# the edge entry preceeding self.max_edge_idx should exist
 		if verbose:
 			print 'checking that self.max_edge_idx edge exists'
-		
+
 		assert self.max_edge_idx >= -1, 'self.max_edge_idx is invalid (= %d)' % self.max_edge_idx
 		assert self.max_edge_idx == -1 or self.edge_info[self.max_edge_idx].exists, 'The edge entry at self.max_edge_idx does not exist'
-		
+
 		# count the number of existing edges
 		if verbose:
 			print 'counting the number of existing edges'
-		
+
 		cdef int num_existing_edges = 0
-		
+
 		for i in range(self.next_edge_idx):
 			if self.edge_info[i].exists:
 				num_existing_edges += 1
-		
+
 		assert num_existing_edges == self.num_edges, '# of existing edges (%d) != self.num_edges (%d)' % (num_existing_edges,self.num_edges)
-		
+
 		# validate the structure of the free edge list
 		if verbose:
 			print 'counting the number of free edges'
-		
+
 		cdef int num_free_edges = 0
 		i = self.first_free_edge
 		j = -1
 		while i != -1:
 			assert 0 <= i < self.edge_capacity, 'Free edge %d has an invalid index (self.edge_capacity = %d)' % (i,self.edge_capacity)
-		
+
 			assert not self.edge_info[i].exists, 'Free edge %d has exists flag set to True' % i
-		
+
 			num_free_edges += 1
-		
+
 			assert self.edge_info[i].tgt == j, 'Free edge %d points to the incorrect predecessor (%d correct, %d actual)' % (i,j,self.edge_info[i].tgt)
-		
+
 			j = i
 			i = self.edge_info[i].src
-		
+
 		assert (num_free_edges + num_existing_edges) == self.next_edge_idx, '(# free edges) + (# existing edges) != self.next_edge_idx (%d + %d != %d)' % (num_free_edges,num_existing_edges,self.next_edge_idx)
 
 	cpdef np.ndarray[np.double_t] matrix(self):
 		"""
 		Construct and return the adjacency matrix.
-	
-		**Returns**: 
+
+		**Returns**:
 			``np.ndarray[double,ndims=2]``, ``M``.  The topology of the graph in adjacency matrix form where ``M[i,j]`` is the
-			weight of the edge between nodes with index ``i`` and ``j``.  If there is no edge between ``i`` and ``j``, then 
+			weight of the edge between nodes with index ``i`` and ``j``.  If there is no edge between ``i`` and ``j``, then
 			``M[i,j] = 0``.
-			
+
 				When using this function, keep in mind that
-				if the graph is not compact, there may be some node indices that don't correspond to valid nodes. 
+				if the graph is not compact, there may be some node indices that don't correspond to valid nodes.
 				In this case, the corresponding matrix elements are not valid.  For example::
-			
+
 					G = DiGraph()
 					G.add_node('a') # this node has index 0
 					G.add_node('b') # this node has index 1
 					G.add_node('c') # this node has index 2
-				
+
 					G.rm_node('b') # after this point, index 1 doesn't correspond to a valid node
-				
+
 					M = G.matrix() # M is a 3x3 matrix
-				
+
 					V = M[1,:] # the values in V are meaningless because a node with index 1 doesn't exist
-				
+
 				This situation can be resolved by making a call to :py:meth:`Graph.compact` prior to calling this function::
-			
+
 					G = DiGraph()
 					G.add_node('a') # this node has index 0
 					G.add_node('b') # this node has index 1
 					G.add_node('c') # this node has index 2
-			
+
 					G.rm_node('b') # after this point, index 1 doesn't correspond to a valid node
-				
-					G.compact() 
+
+					G.compact()
 					# In the call above, we've reassigned node indices so that there are no invalid nodes
 					# this means that nodes 'a' and 'b' have been assigned indices 0 and 1.
-				
+
 					M = G.matrix() # M is a 2x2 matrix
-			
+
 					V = M[1,:] # this is valid now and corresponds to node G.node_object(1)
-				
+
 		"""
 		cdef np.ndarray[np.double_t,ndim=2] A = np.zeros( (self.next_node_idx,self.next_node_idx), np.double)
 		cdef int i, j, u, eidx, v
@@ -485,15 +485,15 @@ cdef class DiGraph:
 					A[u,v] = w
 
 		return A
-	
+
 	cpdef copy(DiGraph self):
 		"""
-		Create a copy of this graph.  
-	
+		Create a copy of this graph.
+
 		.. note:: that node and edge indices are preserved in this copy.
-	
-		**Returns**: 
-			:py:class:`zen.DiGraph`. A new graph object that contains an independent copy of the connectivity of this graph.  
+
+		**Returns**:
+			:py:class:`zen.DiGraph`. A new graph object that contains an independent copy of the connectivity of this graph.
 			Node objects and node/edge data in the new graph reference the same objects as in the old graph.
 		"""
 		cdef DiGraph G = DiGraph()
@@ -517,82 +517,82 @@ cdef class DiGraph:
 				G.add_edge_x(eidx,i,j,edata,weight)
 
 		return G
-				
+
 	cpdef bint is_directed(DiGraph self):
 		"""
 		Return ``True`` if this graph is directed (which it is).
 		"""
 		return True
-	
+
 	cpdef bint is_compact(DiGraph self):
 		"""
-		Return ``True`` if the graph is in compact form.  
-		
+		Return ``True`` if the graph is in compact form.
+
 		A graph is compact if there are no unallocated node or edge indices.
 		The graph can be compacted by calling the :py:meth:`DiGraph.compact` method.
 		"""
 		return (self.num_nodes == (self.max_node_idx + 1) and self.num_edges == (self.max_edge_idx + 1))
-	
+
 	cpdef compact(DiGraph self):
 		"""
 		Compact the graph in place.  This will re-assign:
-		
+
 			#. node indices such that there are no unallocated node indices less than self.max_node_idx
 			#. edge indices such that there are no unallocated edge indices less than self.max_edge_idx
-			
+
 		.. note:: At present no way is provided of keeping track of the changes made to node and edge indices.
 		"""
 		cdef int next_free_idx
 		cdef int src, dest
 		cdef int u,v,i
 		cdef int nidx,eidx
-		
+
 		#####
 		# move the nodes around
 		nidx = 0
 		while nidx < self.max_node_idx:
-			
+
 			if self.node_info[nidx].exists:
 				nidx += 1
 				continue
-			
-			# move all node content 
+
+			# move all node content
 			src = self.max_node_idx
 			dest = nidx
 			self.node_info[dest] = self.node_info[src]
 			self.node_info[src].exists = False
-			
+
 			# move the node object references
 			if src in self.node_obj_lookup:
 				obj = self.node_obj_lookup[src]
 				self.node_obj_lookup[dest] = obj
 				del self.node_obj_lookup[src]
 				self.node_idx_lookup[obj] = dest
-				
+
 			# move the node data
 			if src in self.node_data_lookup:
 				self.node_data_lookup[dest] = self.node_data_lookup[src]
 				del self.node_data_lookup[src]
-			
+
 			#####
 			# modify all the out-bound edges (and the relevant nodes)
 			for i in range(self.node_info[dest].outdegree):
 				eidx = self.node_info[dest].outelist[i]
-				
+
 				# get the other node whose edge list we need to update
 				v = self.edge_info[eidx].tgt
-				
+
 				#####
 				# update the other node's edge list
-				
+
 				# remove the entry for src
 				self.__remove_edge_from_inelist(v,eidx,src)
-				
+
 				self.edge_info[eidx].src = dest
-				
+
 				# insert the entry for dest
 				self.__insert_edge_into_inelist(v,eidx,dest)
-				
+
 			#####
 			# modify all the in-bound edges (and the relevant nodes)
 			for i in range(self.node_info[dest].indegree):
@@ -611,17 +611,17 @@ cdef class DiGraph:
 
 				# insert the entry for dest
 				self.__insert_edge_into_outelist(u,eidx,dest)
-								
+
 			# update the max node index
 			while self.max_node_idx >= 0 and not self.node_info[self.max_node_idx].exists:
 				self.max_node_idx -= 1
 
 			# move to the next node
 			nidx += 1
-			
+
 		self.next_node_idx = self.max_node_idx + 1
 		self.first_free_node = -1
-				
+
 		#####
 		# move the edges around
 		eidx = 0
@@ -629,35 +629,35 @@ cdef class DiGraph:
 			if self.edge_info[eidx].exists:
 				eidx += 1
 				continue
-			
+
 			# move all edge content from the last element to the first free edge
 			src = self.max_edge_idx
 			dest = eidx
 			self.edge_info[dest] = self.edge_info[src]
 			self.edge_info[src].exists = False
-			
+
 			# move the edge data
 			if src in self.edge_data_lookup:
 				self.edge_data_lookup[dest] = self.edge_data_lookup[src]
 				del self.edge_data_lookup[src]
-			
+
 			#####
 			# change entries in u and v
 			u = self.edge_info[dest].src
 			v = self.edge_info[dest].tgt
-		
+
 			# in u
 			i = self.find_outelist_insert_pos(self.node_info[u].outelist,self.node_info[u].outdegree,v)
 			self.node_info[u].outelist[i] = dest
-		
+
 			# in v
 			i = self.find_inelist_insert_pos(self.node_info[v].inelist,self.node_info[v].indegree,u)
 			self.node_info[v].inelist[i] = dest
-			
+
 			# wipe out the source edge info
 			self.edge_info[src].src = -1
 			self.edge_info[src].tgt = -1
-			
+
 			# update the max node index
 			while self.max_edge_idx >= 0 and not self.edge_info[self.max_edge_idx].exists:
 				self.max_edge_idx -= 1
@@ -668,94 +668,94 @@ cdef class DiGraph:
 		# at this point the max number of nodes and the next node available are adjacent
 		self.first_free_edge = -1
 		self.next_edge_idx = self.max_edge_idx + 1
-		
+
 		return
-					
+
 	cpdef skeleton(self,data_merge_fxn=NO_NONE_LIST_OF_DATA,weight_merge_fxn=AVG_OF_WEIGHTS):
 		"""
-		Create an undirected version of this graph. 
-		
+		Create an undirected version of this graph.
+
 		.. note::
 			Node indices will be preserved in the undirected graph that is returned.  Edge indices,
 			however, will not due to the fact that the number of edges present in the graph returned
 			may be smaller.
-		
+
 		**Args**:
-			
-			* ``data_merge_fxn [=NO_NONE_LIST_OF_DATA]``: decides how the data objects associated 
+
+			* ``data_merge_fxn [=NO_NONE_LIST_OF_DATA]``: decides how the data objects associated
 				with reciprocal	edges will be combined into a data object for a single undirected edge.
 				Valid values values are:
-			
+
 				* ``NO_NONE_LIST_OF_DATA``: a list of the data objects if the both data
 			  		objects are not None.  Otherwise, the value will be set to None.
 				* ``LIST_OF_DATA``: a list of the data objects regardless of their values.
 				* an arbitrary function of the form ``merge(i,j,d1,d2)`` that returns a single object.
-			  		In this instance, ``d1`` is the data associated with edge ``(i,j)`` and 
+			  		In this instance, ``d1`` is the data associated with edge ``(i,j)`` and
 			  		``d2`` is the data object associated with edge ``(j,i)``.  Note that ``i`` and ``j``
 			  		are node indices, not objects.
-		
-			* ``weight_merge_fxn [=AVG_OF_WEIGHTS]``: decides how the values of reciprocal edges will be 
+
+			* ``weight_merge_fxn [=AVG_OF_WEIGHTS]``: decides how the values of reciprocal edges will be
 				combined into a single undirected edge.  Valid values are:
-		
+
 				* ``AVG_OF_WEIGHTS``: average the two weights
 			 	* ``MIN_OF_WEIGHTS``: take the min value of the weights
 				* ``MAX_OF_WEIGHTS``: take the max value of the two weights
-				* an arbitrary function of the form ``merge(i,j,w1,w2)`` that returns a ``float``. 
-			  In this instance, ``w1`` is the weight associated with edge ``(i,j)`` and 
-			  ``w2`` is the weight associated with edge ``(j,i)``. Note that ``i`` and ``j`` are 
+				* an arbitrary function of the form ``merge(i,j,w1,w2)`` that returns a ``float``.
+			  In this instance, ``w1`` is the weight associated with edge ``(i,j)`` and
+			  ``w2`` is the weight associated with edge ``(j,i)``. Note that ``i`` and ``j`` are
 			  node indices, not objects.
-			
+
 		**Returns**:
 			:py:class:`zen.Graph`. The undirected version of this graph.
-			
+
 		**Raises**:
 			:py:exc:`zen.ZenException`: if either ``data_merge_fxn`` or ``weight_merge_fxn`` are not properly defined.
 		"""
 		cdef Graph G = Graph()
 		cdef int i,j,eidx,eidx2
 		cdef double weight, weight2
-		
+
 		cdef int _CUSTOM_WEIGHT_FXN = -1
 		cdef int _AVG_OF_WEIGHTS = AVG_OF_WEIGHTS
 		cdef int _MIN_OF_WEIGHTS = MIN_OF_WEIGHTS
 		cdef int _MAX_OF_WEIGHTS = MAX_OF_WEIGHTS
-		
+
 		cdef int _CUSTOM_DATA_FXN = -1
 		cdef int _NO_NONE_LIST_OF_DATA = NO_NONE_LIST_OF_DATA
 		cdef int _LIST_OF_DATA = LIST_OF_DATA
-		
+
 		cdef int weight_merge_switch = _CUSTOM_WEIGHT_FXN
 		if type(weight_merge_fxn) == int:
 			weight_merge_switch = weight_merge_fxn
-		
+
 		cdef int data_merge_switch = _CUSTOM_DATA_FXN
 		if type(data_merge_fxn) == int:
 			data_merge_switch = data_merge_fxn
-		
+
 		for i in range(self.next_node_idx):
 			if self.node_info[i].exists:
 				nobj = self.node_object(i)
 				ndata = self.node_data_(i)
-				
+
 				# adding the node this way preserves the node indices
 				G.add_node_x(i,G.edge_list_capacity,nobj,ndata)
-		
+
 		for eidx in range(self.next_edge_idx):
 			if self.edge_info[eidx].exists:
 				i = self.edge_info[eidx].src
 				j = self.edge_info[eidx].tgt
 				edata = self.edge_data_(eidx)
 				weight = self.weight_(eidx)
-				
+
 				if not G.has_edge_(i,j):
 					eidx2 = G.add_edge_(i,j,edata)
 					G.set_weight_(eidx2,weight)
 				else:
 					eidx2 = G.edge_idx_(i,j)
-					
+
 					### Merge the weights
 					weight2 = G.weight_(eidx2)
-					
+
 					if weight_merge_switch == _AVG_OF_WEIGHTS:
 						weight2 = (weight2 + weight) / 2.0
 					elif weight_merge_switch == _MIN_OF_WEIGHTS:
@@ -766,9 +766,9 @@ cdef class DiGraph:
 						weight2 = weight_merge_fxn(i,j,weight,weight2)
 					else:
 						raise ZenException, 'Weight merge function switch %d (weight_merge_fxn = %s) is not defined' % (weight_merge_switch,str(weight_merge_fxn))
-					
+
 					G.set_weight_(eidx2,weight2)
-					
+
 					### Merge the data
 					edata2 = G.edge_data_(eidx2)
 					if data_merge_switch == _NO_NONE_LIST_OF_DATA and edata is None and edata2 is None:
@@ -780,13 +780,13 @@ cdef class DiGraph:
 						G.set_edge_data_(eidx2,data_merge_fxn(i,j,edata,edata2))
 					else:
 						raise ZenException, 'Data merge function switch %d (data_merge_fxn = %s) is not defined' % (data_merge_switch,str(data_merge_fxn))
-						
+
 		return G
-		
+
 	cpdef reverse(self):
 		"""
 		Create a directed graph with identical content in which edge directions have been reversed.
-		
+
 		.. note::
 		 	Node and edge indices are preserved in the reversed graph.
 		"""
@@ -816,25 +816,25 @@ cdef class DiGraph:
 	cpdef np.ndarray[np.int_t] add_nodes(self,int num_nodes,node_obj_fxn=None):
 		"""
 		Add a specified set of nodes to the graph.
-		
+
 		**Args**:
-		
+
 			* ``num_nodes`` (int): the number of nodes to add to the graph.
 			* ``node_obj_fxn [=None]`` (callable): a callable object (typically a function) that accepts a node index (an integer)
-				and returns the object that will be used as the object for that node in the graph.  If this is not specified, then 
+				and returns the object that will be used as the object for that node in the graph.  If this is not specified, then
 				no node objects will be assigned to nodes.
-				
+
 		**Returns**:
 			``np.ndarray[int,ndims=1]``, ``I``. The node indices of the nodes added where ``I[j]`` is the index of the jth node added by this
 			function call.
-			
+
 		**Raises**:
 			:py:exc:`ZenException`: if a node could not be added.
 		"""
 		cdef int nn_count
 		cdef np.ndarray[np.int_t,ndim=1] indexes = np.empty( num_nodes, np.int)
 		cdef int node_idx
-		
+
 		self.num_changes += 1
 
 		for nn_count in range(num_nodes):
@@ -855,34 +855,34 @@ cdef class DiGraph:
 			self.add_node_x(node_idx,self.edge_list_capacity,self.edge_list_capacity,nobj,None)
 
 		return indexes
-					
+
 	cpdef int add_node(DiGraph self,nobj=None,data=None) except -1:
 		"""
 		Add a node to this graph.
-		
+
 		**Args**:
-		
+
 			* ``nobj [=None]``: the (optional) object that will be a convenient identifier for this node.
 			* ``data [=None]``: an optional data object to associated with this node.
-		
+
 		**Returns**:
 			``int``. The index of the new node.
-			
+
 		**Raises**:
 			:py:exc:`ZenException`: if the node could not be added.
 		"""
 		cdef int node_idx
-		
+
 		# recycle an unused node index if possible
 		if self.first_free_node != -1:
 			node_idx = self.first_free_node
 		else:
 			node_idx = self.next_node_idx
-			
+
 		self.add_node_x(node_idx,self.edge_list_capacity,self.edge_list_capacity,nobj,data)
-		
+
 		return node_idx
-		
+
 	cdef add_to_free_node_list(self,int nidx):
 		self.node_info[nidx].indegree = self.first_free_node
 		self.node_info[nidx].in_capacity = -1
@@ -903,43 +903,43 @@ cdef class DiGraph:
 
 		if next_free_node != -1:
 			self.node_info[next_free_node].in_capacity = prev_free_node
-				
+
 	cpdef add_node_x(DiGraph self,int node_idx,int in_edge_list_capacity,int out_edge_list_capacity,nobj,data):
 		"""
 		Adds a node to the graph with a specific node index.
-		
+
 		This function permits very high-performance population of the graph data structure
 		with nodes by allowing the calling function to specify the node index and edge
 		capacity of the node being added.  In general, this should only be done when the node indices
 		have been obtained from a previously stored graph data structure.
-		
-		.. DANGER:: 
-			This function should be used with great care because by specifying a node index, the 
-			calling function is forcing Zen to access specific parts of the memory allocated for nodes.  
+
+		.. DANGER::
+			This function should be used with great care because by specifying a node index, the
+			calling function is forcing Zen to access specific parts of the memory allocated for nodes.
 			Unless you are writing high-performance network loading code, you should not be calling
 			this function directly.
-			
-			When used incorrectly, this method call can irreparably damage the integrity of the graph object, 
+
+			When used incorrectly, this method call can irreparably damage the integrity of the graph object,
 			leading to incorrect results or, more likely, segmentation faults.
-			
+
 		**Args**:
-		
+
 			* ``node_idx`` (int): the node index this node should be assigned.
 			* ``in_edge_list_capacity`` (int): the number of entries that should be allocated in the edge list for this node.
 			* ``out_edge_list_capacity`` (int): the number of entries that should be allocated in the edge list for this node.
 			* ``nobj``: the node object that will be associated with this node.  If ``None``, then no object will be
 				assigned to this node.
-			* ``data``: the data object that will be associated with this node.  If ``None``, then no data will be 
+			* ``data``: the data object that will be associated with this node.  If ``None``, then no data will be
 				assigned to this node.
-				
+
 		**Raises**:
 			:py:exc:`ZenException`: if the node index is already in use or the node object is not unique.
 		"""
 		cdef int i
-		
+
 		if node_idx < self.node_capacity and self.node_info[node_idx].exists:
 			raise ZenException, 'Adding node at index %d will overwrite an existing node' % node_idx
-			
+
 		if node_idx >= self.next_node_idx:
 			# if we got in here, then we must be in the
 			# domain beyond the next_node_idx - these are the nodes
@@ -959,56 +959,56 @@ cdef class DiGraph:
 			self.max_node_idx = node_idx
 
 		self.num_changes += 1
-		
+
 		if nobj is not None:
 			self.node_idx_lookup[nobj] = node_idx
 			self.node_obj_lookup[node_idx] = nobj
-			
+
 		if data is not None:
 			self.node_data_lookup[node_idx] = data
-		
+
 		# grow the node_info array as necessary
 		cdef int new_node_capacity
 		if node_idx >= self.node_capacity:
 			new_node_capacity = <int> ceil( float(self.node_capacity) * self.node_grow_factor)
 			if node_idx >= new_node_capacity:
 				new_node_capacity = node_idx + 1
-			
+
 			self.node_info = <NodeInfo*> stdlib.realloc(self.node_info, sizeof_NodeInfo*new_node_capacity)
 			for i in range(self.node_capacity,new_node_capacity):
 				self.node_info[i].exists = False
-				
+
 			# add all the newly allocated empty nodes to the free node list
 			for i in range(self.node_capacity,node_idx):
 				self.add_to_free_node_list(i)
-					
+
 			self.node_capacity = new_node_capacity
-			
+
 		self.node_info[node_idx].exists = True
 		self.node_info[node_idx].indegree = 0
 		self.node_info[node_idx].outdegree = 0
-		
+
 		# initialize edge lists
 		self.node_info[node_idx].inelist = <int*> stdlib.malloc(sizeof(int) * self.edge_list_capacity)
 		self.node_info[node_idx].in_capacity = self.edge_list_capacity
 		self.node_info[node_idx].outelist = <int*> stdlib.malloc(sizeof(int) * self.edge_list_capacity)
 		self.node_info[node_idx].out_capacity = self.edge_list_capacity
-		
+
 		self.num_nodes += 1
 		return
-	
+
 	def __contains__(DiGraph self,nobj):
 		"""
 		Return ``True`` if object ``nobj`` is associated with a node in this graph.
 		"""
 		return nobj in self.node_idx_lookup
-	
+
 	cpdef int node_idx(DiGraph self,nobj) except -1:
 		"""
 		Return the index of the node with node object ``nobj``.
 		"""
 		return self.node_idx_lookup[nobj]
-		
+
 	cpdef node_object(DiGraph self,int nidx):
 		"""
 		Return the object associated with node having index ``nidx``.  If no object is associated, then ``None`` is returned.
@@ -1017,19 +1017,19 @@ cdef class DiGraph:
 			return self.node_obj_lookup[nidx]
 		else:
 			return None
-	
+
 	cpdef set_node_object(self,curr_node_obj,new_node_obj):
 		"""
-		Change the node object associated with a specific node.  
-		
+		Change the node object associated with a specific node.
+
 		.. note::
 			The new object must be unique among all other node objects.
-			
+
 		**Args**:
-		
+
 			* ``curr_node_obj``: the current node object to change.
 			* ``new_node_obj``: the object to replace the current node object with.
-			
+
 		**Raises**:
 			:py:exc:`ZenException`: if the new key object is not unique in the graph.
 		"""
@@ -1045,16 +1045,16 @@ cdef class DiGraph:
 
 	cpdef set_node_object_(self,node_idx,new_node_obj):
 		"""
-		Change the node object associated with a specific node.  
-	
+		Change the node object associated with a specific node.
+
 		.. note::
 			The new object must be unique among all other node objects.
-		
+
 		**Args**:
-	
+
 			* ``node_idx``: the index of the node to set the object for.
 			* ``new_node_obj``: the object to replace the current node object with.
-		
+
 		**Raises**:
 			:py:exc:`ZenException`: if the new key object is not unique in the graph.
 		"""
@@ -1071,7 +1071,7 @@ cdef class DiGraph:
 			del self.node_idx_lookup[self.node_obj_lookup[node_idx]]
 		self.node_idx_lookup[new_node_obj] = node_idx
 		self.node_obj_lookup[node_idx] = new_node_obj
-					
+
 	cpdef node_data(DiGraph self,nobj):
 		"""
 		Return the data object associated with node having object identifier ``nobj``.
@@ -1082,29 +1082,29 @@ cdef class DiGraph:
 		"""
 		Associate a new data object with a specific node in the network.
 		If data is None, then any data associated with the node is deleted.
-		
+
 		**Args**:
-		
+
 			* ``nobj``: the node object identifying the node whose data association is being changed.
 			* ``data``: the data object to associate.  If ``None``, then any data object currently
 				associated with this node will be deleted.
 		"""
 		self.set_node_data_(self.node_idx_lookup[nobj],data)
-		
+
 	cpdef set_node_data_(DiGraph self,int nidx,data):
 		"""
 		Associate a new data object with a specific node in the network.
 		If data is None, then any data associated with the node is deleted.
-	
+
 		**Args**:
-	
+
 			* ``nidx``: the index of the node whose data association is being changed.
 			* ``data``: the data object to associate.  If ``None``, then any data object currently
 				associated with this node will be deleted.
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node index %d' % nidx
-		
+
 		if data == None:
 			if nidx in self.node_data_lookup:
 				del self.node_data_lookup[nidx]
@@ -1117,16 +1117,16 @@ cdef class DiGraph:
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node index %d' % nidx
-			
+
 		if nidx in self.node_data_lookup:
 			return self.node_data_lookup[nidx]
 		else:
 			return None
-		
+
 	cpdef nodes_iter(DiGraph self,data=False):
 		"""
-		Return an iterator over all the nodes in the graph.  
-		
+		Return an iterator over all the nodes in the graph.
+
 		By default, the iterator yields node objects.  If ``data`` is ``True``,
 		then the iterator yields tuples ``(node_object,node_data)``.
 		"""
@@ -1134,35 +1134,35 @@ cdef class DiGraph:
 
 	cpdef nodes_iter_(DiGraph self,obj=False,data=False):
 		"""
-		Return an iterator over all the nodes in the graph.  
-	
-		By default, the iterator yields node indices.  If either ``obj`` or ``data`` are ``True``, then 
+		Return an iterator over all the nodes in the graph.
+
+		By default, the iterator yields node indices.  If either ``obj`` or ``data`` are ``True``, then
 		tuples are yielded.  For example::
-		
+
 			for nidx in G.node_iter_():
 				print 'Node index:',nidx
-				
+
 			for nidx,obj in G.node_iter_(obj=True):
 				print 'Node index:',nidx,'Node object:',obj
-				
+
 			for nidx,obj,data in G.node_iter_(True,True):
 				print nidx,obj,data
-		
+
 		"""
 		return NodeIterator(self,obj,data,False)
-				
+
 	cpdef nodes(DiGraph self,data=False):
 		"""
 		Return a list of the node objects in the graph.
-		
+
 		.. note::
 			This method is only valid for graphs in which all nodes have a node object.
-		
-		By default, the list contains node objects for all nodes.  If ``data`` is ``True``, 
+
+		By default, the list contains node objects for all nodes.  If ``data`` is ``True``,
 		then the list contains tuples containing the node object and associated data.
 		"""
 		result = []
-		
+
 		cdef int idx = 0
 		cdef int i = 0
 		while idx < self.num_nodes:
@@ -1177,20 +1177,20 @@ cdef class DiGraph:
 				else:
 					result.append(self.node_obj_lookup[i])
 				idx += 1
-				
+
 			i += 1
-			
+
 		return result
 
 	cpdef nodes_(DiGraph self,obj=False,data=False):
 		"""
-		Return a numpy array of the nodes.  
-		
+		Return a numpy array of the nodes.
+
 		By default, the array is 1-D and contains only node indices.  If either ``obj`` or ``data``
-		are ``True``, then the result is a 2-D matrix in which the additional columns contain 
+		are ``True``, then the result is a 2-D matrix in which the additional columns contain
 		the node object and/or data.
-		
-		.. note:: 
+
+		.. note::
 			If ``obj`` and ``data`` are both ``False``, then the numpy array returned has type ``int``.  When used
 			with cython, this fact can be used to dramatically increase the speed of code iterating
 			over a graph's nodes.
@@ -1205,8 +1205,8 @@ cdef class DiGraph:
 
 		cdef int idx = 0
 		cdef int i = 0
-		
-		if ndim == 1:		
+
+		if ndim == 1:
 			for i in range(self.next_node_idx):
 				if self.node_info[i].exists:
 					result[idx] = i
@@ -1247,58 +1247,58 @@ cdef class DiGraph:
 						result[idx,2] = self.node_data_lookup[i]
 					else:
 						result[idx,2] = None
-						
+
 					idx += 1
 
-				i += 1		
-						
+				i += 1
+
 		return result
-		
+
 	cpdef rm_node(DiGraph self,nobj):
 		"""
 		Remove the node associated with node object ``nobj``.  Any edges incident to the node are also removed
 		from the graph.
 		"""
 		self.rm_node_(self.node_idx_lookup[nobj])
-	
+
 	cpdef rm_node_(DiGraph self,int nidx):
 		"""
 		Remove the node with index ``nidx``. Any edges incident to the node are also removed from the graph.
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node index %d' % nidx
-			
+
 		cdef int i
-		
+
 		self.num_changes += 1
-		
+
 		# disconnect all inbound edges
 		for i in range(self.node_info[nidx].indegree-1,-1,-1):
 			eidx = self.node_info[nidx].inelist[i]
-			
+
 			# remove the edge
 			self.rm_edge_(eidx)
-		
+
 		# disconnect all outbound edges
 		for i in range(self.node_info[nidx].outdegree-1,-1,-1):
 			eidx = self.node_info[nidx].outelist[i]
-			
+
 			# remove the edge
 			self.rm_edge_(eidx)
-		
+
 		# free up all the data structures
 		self.node_info[nidx].exists = False
 		stdlib.free(self.node_info[nidx].inelist)
 		stdlib.free(self.node_info[nidx].outelist)
-	
+
 		if nidx in self.node_data_lookup:
 			del self.node_data_lookup[nidx]
-			
+
 		if nidx in self.node_obj_lookup:
 			nobj = self.node_obj_lookup[nidx]
 			del self.node_obj_lookup[nidx]
 			del self.node_idx_lookup[nobj]
-		
+
 		# keep track of the free node
 		self.add_to_free_node_list(nidx)
 
@@ -1306,9 +1306,9 @@ cdef class DiGraph:
 		if nidx == self.max_node_idx:
 			while self.max_node_idx >= 0 and not self.node_info[self.max_node_idx].exists:
 				self.max_node_idx -= 1
-				
+
 		self.num_nodes -= 1
-	
+
 	cpdef degree(DiGraph self,nobj):
 		"""
 		Return the degree of node with object ``nobj``.
@@ -1321,140 +1321,140 @@ cdef class DiGraph:
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node index %d' % nidx
-			
+
 		return self.node_info[nidx].indegree + self.node_info[nidx].outdegree
-	
+
 	cpdef in_degree(DiGraph self,nobj):
 		"""
 		Return the in-degree of node with object ``nobj``.
 		"""
 		return self.in_degree_(self.node_idx_lookup[nobj])
-	
+
 	cpdef in_degree_(DiGraph self,int nidx):
 		"""
 		Return the in-degree of node with index ``nidx``.
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node index %d' % nidx
-			
+
 		return self.node_info[nidx].indegree
-	
+
 	cpdef out_degree(DiGraph self,nobj):
 		"""
 		Return the out-degree of node with object ``nobj``.
 		"""
 		return self.out_degree_(self.node_idx_lookup[nobj])
-	
+
 	cpdef out_degree_(DiGraph self,int nidx):
 		"""
 		Return the out-degree of node with index ``nidx``.
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node index %d' % nidx
-			
+
 		return self.node_info[nidx].outdegree
-	
+
 	def __getitem__(self,nobj):
 		"""
 		Get the data for the node associated with ``nobj``.
 		"""
 		return self.node_data_lookup[self.node_idx_lookup[nobj]]
-	
+
 	def __len__(self):
 		"""
 		Return the number of nodes in the graph.
 		"""
 		return self.num_nodes
-		
+
 	def size(self):
 		"""
 		Return the number of edges in the graph.
 		"""
 		return self.num_edges
-	
+
 	cpdef int add_edge(self, src, tgt, data=None, double weight=1) except -1:
 		"""
 		Add an edge to the graph.
-		
+
 		As a convenience, if ``src`` or ``tgt`` are not valid node objects, they will be added to the graph
 		and then the edge will be added.::
-		
+
 			G = DiGraph()
-			
+
 			print len(G) # prints '0'
 			G.add_edge(1,2) # First nodes 1 and 2 will be added, then the edge will be added
 			print len(G) # prints '2' since there are now two nodes in the graph.
-			
-		
+
+
 		**Args**:
-		
+
 			* ``src``: the node from which the edge originates
 			* ``tgt``: the node at which the edge terminates
 			* ``data [=None]``: an optional data object to associate with the edge
 			* ``weight [=1]`` (float): the weight of the edge.
-			
+
 		**Returns**:
 			``integer``. The index for the newly created edge.
-			
+
 		**Raises**:
 			:py:exc:`ZenException`: if the edge already exists in the graph.
-			
+
 		"""
 		cdef int nidx1, nidx2
-		
+
 		if src not in self.node_idx_lookup:
 			nidx1 = self.add_node(src)
 		else:
 			nidx1 = self.node_idx_lookup[src]
-		
+
 		if tgt not in self.node_idx_lookup:
 			nidx2 = self.add_node(tgt)
 		else:
 			nidx2 = self.node_idx_lookup[tgt]
-		
+
 		result = self.add_edge_(nidx1,nidx2,data,weight)
-		
+
 		return result
-	
+
 	cpdef int add_edge_(DiGraph self, int src, int tgt, data=None, double weight=1) except -1:
 		"""
 		Add an edge to the graph.
-		
+
 		This version of the edge addition functionality uses node indices (not node objects).
 		Unlike in :py:method:``.add_edge``, if ``src`` or ``tgt`` are not valid node indices, then an
-		exception will be raised.	
-		
+		exception will be raised.
+
 		**Args**:
-		
+
 			* ``src`` (int): the node from which the edge originates. This should be a node index.
 			* ``tgt`` (int): the node at which the edge terminates. This should be a node index.
 			* ``data [=None]``: an optional data object to associate with the edge
 			* ``weight [=1]`` (float): the weight of the edge.
-			
+
 		**Returns**:
 			``integer``. The index for the newly created edge.
-			
+
 		**Raises**:
 			:py:exc:`ZenException`: if the edge already exists in the graph or if either of the node indices are invalid.
 		"""
 		cdef int i
 		self.num_changes += 1
-		
+
 		if src >= self.node_capacity or not self.node_info[src].exists or tgt >= self.node_capacity or not self.node_info[tgt].exists:
 			raise ZenException, 'Both source and destination nodes must exist (%d,%d)' % (src,tgt)
-			
+
 		cdef int eidx
-		
+
 		# recycle an edge index if possible
 		if self.first_free_edge != -1:
 			eidx = self.first_free_edge
 		else:
 			eidx = self.next_edge_idx
-		
+
 		self.add_edge_x(eidx,src,tgt,data,weight)
-		
+
 		return eidx
-	
+
 	cdef add_to_free_edge_list(self,int eidx):
 		self.edge_info[eidx].src = self.first_free_edge
 		self.edge_info[eidx].tgt = -1
@@ -1475,42 +1475,42 @@ cdef class DiGraph:
 
 		if next_free_edge != -1:
 			self.edge_info[next_free_edge].tgt = prev_free_edge
-					
+
 	cpdef int add_edge_x(DiGraph self, int eidx, int src, int tgt, data, double weight) except -1:
 		"""
 		Adds an edge to the graph with a specific edge index.
-	
+
 		This function permits very high-performance population of the graph data structure
-		with edges by allowing the calling function to specify the edge index of the edge being added.  
-		In general, this should only be done when the edge indices have been obtained from a previously 
+		with edges by allowing the calling function to specify the edge index of the edge being added.
+		In general, this should only be done when the edge indices have been obtained from a previously
 		stored graph data structure.
-	
-		.. DANGER:: 
-			This function should be used with great care because by specifying a edge index, the 
-			calling function is forcing Zen to access specific parts of the memory allocated for edge.  
+
+		.. DANGER::
+			This function should be used with great care because by specifying a edge index, the
+			calling function is forcing Zen to access specific parts of the memory allocated for edge.
 			Unless you are writing high-performance network loading code, you should not be calling
 			this function directly.
-		
-			When used incorrectly, this method call can irreparably damage the integrity of the graph object, 
+
+			When used incorrectly, this method call can irreparably damage the integrity of the graph object,
 			leading to incorrect results or, more likely, segmentation faults.
-		
+
 		**Args**:
-	
+
 			* ``eidx`` (int): the edge index this node should be assigned.
 			* ``src`` (int): the node from which the edge originates. This should be a node index.
 			* ``tgt`` (int): the node at which the edge terminates. This should be a node index.
 			* ``nobj``: the node object that will be associated with this node.  If ``None``, then no object will be
 				assigned to this node.
-			* ``data``: the data object that will be associated with this node.  If ``None``, then no data will be 
+			* ``data``: the data object that will be associated with this node.  If ``None``, then no data will be
 				assigned to this node.
-			
+
 		**Raises**:
 			:py:exc:`ZenException`: if the edge already exists in the graph, the edge index is already in use, or either of the
 			node indices are invalid.
 		"""
 		if eidx < self.edge_capacity and self.edge_info[eidx].exists:
 			raise ZenException, 'Adding edge at index %d will overwrite an existing edge' % eidx
-		
+
 		# grow the info array
 		cdef int new_edge_capacity
 		if eidx >= self.edge_capacity:
@@ -1518,24 +1518,24 @@ cdef class DiGraph:
 			self.edge_info = <EdgeInfo*> stdlib.realloc( self.edge_info, sizeof_EdgeInfo * new_edge_capacity)
 			for i in range(self.edge_capacity,new_edge_capacity):
 				self.edge_info[i].exists = False
-					
+
 			self.edge_capacity = new_edge_capacity
-		
+
 		####
 		# connect up the edges to nodes
-		
+
 		# Note: this is where duplicate edges are detected.  So
 		# an exception can be thrown by these two functions.  Hence,
 		# it's necessary to make modifications to the edge list *AFTER*
 		# these functions both successfully return.
-		
+
 		# source
 		self.__insert_edge_into_outelist(src,eidx,tgt)
-		
+
 		# destination
-		self.__insert_edge_into_inelist(tgt,eidx,src)	
-		
-		# obtain the node index from the 
+		self.__insert_edge_into_inelist(tgt,eidx,src)
+
+		# obtain the node index from the
 		if eidx >= self.next_edge_idx:
 			# if we got in here, then we must be in the
 			# domain beyond the next_edge_idx - these are the edges
@@ -1553,23 +1553,23 @@ cdef class DiGraph:
 		# update the max_edge_idx to keep track of the maximum value existing index
 		if eidx > self.max_edge_idx:
 			self.max_edge_idx = eidx
-		
-		# set the data if provided	
+
+		# set the data if provided
 		if data is not None:
 			self.edge_data_lookup[eidx] = data
-			
+
 		### Add edge info
 		self.edge_info[eidx].exists = True
 		self.edge_info[eidx].src = src
 		self.edge_info[eidx].tgt = tgt
 		self.edge_info[eidx].weight = weight
-		
+
 		#####
 		# Done
 		self.num_edges += 1
-		
+
 		return eidx
-	
+
 	cdef __insert_edge_into_outelist(DiGraph self, int src, int eidx, int tgt):
 		cdef int new_capacity
 		cdef int num_edges = self.node_info[src].outdegree
@@ -1589,7 +1589,7 @@ cdef class DiGraph:
 			memmove(elist + (pos+1),elist + pos,(num_edges-pos) * sizeof(int))
 			elist[pos] = eidx
 		self.node_info[src].outdegree += 1
-	
+
 	cdef __insert_edge_into_inelist(DiGraph self, int tgt, int eidx, int src):
 		cdef int new_capacity
 		cdef int pos = 0
@@ -1607,22 +1607,22 @@ cdef class DiGraph:
 			memmove(elist + (pos+1),elist + pos,(num_edges-pos) * sizeof(int))
 			elist[pos] = eidx
 		self.node_info[tgt].indegree += 1
-	
+
 	cdef int find_inelist_insert_pos(DiGraph self, int* elist, int elist_len, int nidx):
 		"""
 		Perform a binary search for the insert position
 		"""
 		cdef int pos = <int> floor(elist_len/2)
-		
+
 		if elist_len == 0:
 			return 0
-			
+
 		if pos == 0:
 			if self.edge_info[elist[pos]].src < nidx:
 				return elist_len
 			else:
 				return 0
-		
+
 		while True:
 			if pos == 0:
 				return 0
@@ -1636,7 +1636,7 @@ cdef class DiGraph:
 				else:
 					elist_len = pos
 					pos = <int> floor(pos/2)
-					
+
 	cdef int find_outelist_insert_pos(DiGraph self, int* elist, int elist_len, int nidx):
 		"""
 		Perform a binary search for the insert position
@@ -1665,50 +1665,50 @@ cdef class DiGraph:
 				else:
 					elist_len = pos
 					pos = <int> floor(pos/2)
-	
+
 	cpdef rm_edge(DiGraph self,src,tgt):
 		"""
 		Remove the edge connecting node object ``src`` to ``tgt``.
-		
+
 		**Raises**:
-			
+
 			* :py:exc:`ZenException`: if the edge index is invalid.
 			* :py:exc:`KeyError`: if the node objects are invalid.
 		"""
 		self.rm_edge_(self.edge_idx(src,tgt))
-	
+
 	cpdef rm_edge_(DiGraph self,int eidx):
 		"""
 		Remove the edge with index ``eidx``.
-		
+
 		**Raises**:
 			:py:exc:`ZenException`: if ``eid`` is an invalid edge index.
 		"""
 		if eidx >= self.edge_capacity or not self.edge_info[eidx].exists:
 			raise ZenException, 'Invalid edge index %d' % eidx
-		
+
 		cdef int i
-		
+
 		self.num_changes += 1
-		
+
 		#####
 		# remove entries in source and target
 		cdef int src = self.edge_info[eidx].src
 		cdef int tgt = self.edge_info[eidx].tgt
-		
+
 		# in src
 		self.__remove_edge_from_outelist(src,eidx,tgt)
-		
+
 		# in tgt
 		self.__remove_edge_from_inelist(tgt,eidx,src)
-		
+
 		# remove actual data structure
 		self.edge_info[eidx].exists = False
-		
+
 		if eidx in self.edge_data_lookup:
 			data = self.edge_data_lookup[eidx]
 			del self.edge_data_lookup[eidx]
-		
+
 		# add the edge to the list of free edges
 		self.add_to_free_edge_list(eidx)
 
@@ -1716,30 +1716,30 @@ cdef class DiGraph:
 		if eidx == self.max_edge_idx:
 			while self.max_edge_idx >= 0 and not self.edge_info[self.max_edge_idx].exists:
 				self.max_edge_idx -= 1
-				
+
 		self.num_edges -= 1
-		
+
 		return
-	
+
 	cdef __remove_edge_from_outelist(DiGraph self, int src, int eidx, int tgt):
 		cdef int i = self.find_outelist_insert_pos(self.node_info[src].outelist,self.node_info[src].outdegree,tgt)
 		memmove(&self.node_info[src].outelist[i],&self.node_info[src].outelist[i+1],(self.node_info[src].outdegree-i-1)*sizeof(int))
 		self.node_info[src].outdegree -= 1
-		
+
 	cdef __remove_edge_from_inelist(DiGraph self, int tgt, int eidx, int src):
 		cdef int i = self.find_inelist_insert_pos(self.node_info[tgt].inelist,self.node_info[tgt].indegree,src)
 		memmove(&self.node_info[tgt].inelist[i],&self.node_info[tgt].inelist[i+1],(self.node_info[tgt].indegree-i-1)*sizeof(int))
 		self.node_info[tgt].indegree -= 1
-	
+
 	cpdef endpoints(DiGraph self,int eidx):
 		"""
 		Return the node objects at the endpoints of the edge with index ``eidx``.
 		"""
 		if not self.edge_info[eidx].exists:
 			raise ZenException, 'Edge with ID %d does not exist' % eidx
-	
+
 		return self.node_obj_lookup[self.edge_info[eidx].src], self.node_obj_lookup[self.edge_info[eidx].tgt]
-		
+
 	cpdef endpoints_(DiGraph self,int eidx):
 		"""
 		Return the node indices at the endpoints of the edge with index ``eidx``.
@@ -1752,15 +1752,15 @@ cdef class DiGraph:
 	cpdef endpoint(DiGraph self,int eidx,u):
 		"""
 		Return the object for the node (not u) that is the endpoint of this edge.
-		
+
 		.. note::
 			For performance reasons, no check is done to ensure that u is an endpoint of the edge.
-			
+
 		**Args**:
-		
+
 			* ``eidx`` (int): a valid edge index.
 			* ``u``: the object for one endpoint of the edge with index ``eidx``.
-			
+
 		**Returns**:
 			``object``. The object for the node that is the other endpoint of edge ``eidx``.
 		"""
@@ -1774,15 +1774,15 @@ cdef class DiGraph:
 	cpdef int endpoint_(DiGraph self,int eidx,int u) except -1:
 		"""
 		Return the index for the node (not u) that is the endpoint of this edge.
-	
+
 		.. note::
 			For performance reasons, no check is done to ensure that u is an endpoint of the edge.
-		
+
 		**Args**:
-	
+
 			* ``eidx`` (int): a valid edge index.
 			* ``u`` (int): the index for one endpoint of the edge with index ``eidx``.
-		
+
 		**Returns**:
 			``integer``. The index for the node that is the other endpoint of edge ``eidx``.
 		"""
@@ -1808,13 +1808,13 @@ cdef class DiGraph:
 			raise ZenException, 'Invalid edge idx %d' % eidx
 
 		return self.edge_info[eidx].src
-		
+
 	cpdef tgt(DiGraph self,int eidx):
 		"""
 		Return the object for the node at which edge ``eidx`` terminates.
 		"""
 		return self.node_object(self.tgt_(eidx))
-		
+
 	cpdef int tgt_(DiGraph self,int eidx) except -1:
 		"""
 		Return the index for the node at which edge ``eidx`` terminates.
@@ -1823,7 +1823,7 @@ cdef class DiGraph:
 			raise ZenException, 'Invalid edge idx %d' % eidx
 
 		return self.edge_info[eidx].tgt
-		
+
 	cpdef set_weight(DiGraph self,src,tgt,double w):
 		"""
 		Set the weight of the edge connecting node ``src`` to ``tgt`` (node objects) to ``w``.
@@ -1836,7 +1836,7 @@ cdef class DiGraph:
 		"""
 		if eidx >= self.edge_capacity or not self.edge_info[eidx].exists:
 			raise ZenException, 'Invalid edge index %d' % eidx
-		
+
 		self.edge_info[eidx].weight = w
 
 	cpdef double weight(DiGraph self,src,tgt):
@@ -1851,24 +1851,24 @@ cdef class DiGraph:
 		"""
 		if eidx >= self.edge_capacity or not self.edge_info[eidx].exists:
 			raise ZenException, 'Invalid edge index %d' % eidx
-			
+
 		return self.edge_info[eidx].weight
-		
+
 	cpdef set_edge_data(DiGraph self,src,tgt,data):
 		"""
 		Associate a data object with the edge between nodes ``src`` and ``tgt`` (node objects).
-		
+
 		The value of ``data`` will replace any data object currently associated with the edge.
 		If data is None, then any data associated with the edge is deleted.
 		"""
 		self.set_edge_data_(self.edge_idx(src,tgt),data)
-		
+
 	cpdef edge_data(DiGraph self,src,tgt):
 		"""
 		Return the data associated with the edge between ``src`` and ``tgt`` (node objects).
 		"""
 		return self.edge_data_(self.edge_idx(src,tgt))
-	
+
 	cpdef set_edge_data_(DiGraph self,int eidx,data):
 		"""
 		Associate a data object with the edge with index ``eidx``.
@@ -1878,28 +1878,28 @@ cdef class DiGraph:
 		"""
 		if eidx >= self.edge_capacity or not self.edge_info[eidx].exists:
 			raise ZenException, 'Invalid edge index %d' % eidx
-			
+
 		if data == None:
 			if eidx in self.edge_data_lookup:
 				del self.edge_data_lookup[eidx]
 		else:
 			self.edge_data_lookup[eidx] = data
-	
+
 	cpdef edge_data_(DiGraph self,int eidx):
 		"""
 		Return the data associated with the edge with index ``eidx``.
-		"""		
+		"""
 		if eidx >= self.edge_capacity or not self.edge_info[eidx].exists:
 			raise ZenException, 'Invalid edge index %d' % eidx
-	
+
 		if eidx in self.edge_data_lookup:
 			return self.edge_data_lookup[eidx]
 		else:
 			return None
-			
+
 	cpdef bint has_edge(DiGraph self,src,tgt):
 		"""
-		Return ``True`` if the graph contains an edge between ``src`` and ``tgt`` (node objects).  
+		Return ``True`` if the graph contains an edge between ``src`` and ``tgt`` (node objects).
 		If either node object is not in the graph, this method returns ``False``.
 		"""
 		if src not in self.node_idx_lookup:
@@ -1907,30 +1907,30 @@ cdef class DiGraph:
 
 		if tgt not in self.node_idx_lookup:
 			return False
-		
+
 		src = self.node_idx_lookup[src]
 		tgt = self.node_idx_lookup[tgt]
-		
+
 		return self.has_edge_(src,tgt)
-		
+
 	cpdef bint has_edge_(DiGraph self,int src,int tgt):
 		"""
 		Return ``True`` if the graph contains an edge between ``src`` and ``tgt`` (node indices).
-		
+
 		**Raises**:
 			:py:exc:`ZenException`: if either ``src`` or ``tgt`` are invalid node indices.
 		"""
 		if src >= self.node_capacity or not self.node_info[src].exists:
 			raise ZenException, 'Invalid source index %d' % src
-			
+
 		if tgt >= self.node_capacity or not self.node_info[tgt].exists:
 			raise ZenException, 'Invalid target index %d' % tgt
-			
+
 		cdef int num_edges = self.node_info[src].outdegree
 		cdef int* elist = self.node_info[src].outelist
 		cdef int pos = self.find_outelist_insert_pos(elist,self.node_info[src].outdegree,tgt)
 		return pos < self.node_info[src].outdegree and self.edge_info[elist[pos]].tgt == tgt
-	
+
 	cpdef edge_idx(DiGraph self, src, tgt, data=False):
 		"""
 		Return the edge index for the edge between ``src`` and ``tgt`` (node objects).
@@ -1938,160 +1938,160 @@ cdef class DiGraph:
 		src = self.node_idx_lookup[src]
 		tgt = self.node_idx_lookup[tgt]
 		return self.edge_idx_(src,tgt,data)
-	
+
 	cpdef edge_idx_(DiGraph self, int src, int tgt, data=False):
 		"""
 		Return the edge index for the edge between ``src`` and ``tgt`` (node indices).
 		"""
 		if src >= self.node_capacity or not self.node_info[src].exists:
 			raise ZenException, 'Invalid source index %d' % src
-			
+
 		if tgt >= self.node_capacity or not self.node_info[tgt].exists:
 			raise ZenException, 'Invalid target index %d' % tgt
-			
+
 		cdef int num_edges = self.node_info[src].outdegree
 		cdef int* elist = self.node_info[src].outelist
 		cdef int pos = self.find_outelist_insert_pos(elist,self.node_info[src].outdegree,tgt)
-		
+
 		if pos < self.node_info[src].outdegree and self.edge_info[elist[pos]].tgt == tgt:
 			if data is True:
 				return elist[pos], self.edge_data_lookup[elist[pos]]
 			else:
 				return elist[pos]
-		else:			
+		else:
 			raise ZenException, 'Edge (%d,%d) does not exist.' % (src,tgt)
-	
+
 	cpdef edges_iter(DiGraph self,nobj=None,data=False,weight=False):
 		"""
 		Return an iterator over edges in the graph.
-		
+
 		By default, the iterator will cover all edges in the graph, returning each
 		edge as the tuple ``(u,v)``, where ``u`` and ``v`` are (node object) endpoints of the edge.
-		
+
 		**Args**:
-			
-			* ``nobj [=None]``: if ``nobj`` is specified (not ``None``), then the edges touching the node with 
+
+			* ``nobj [=None]``: if ``nobj`` is specified (not ``None``), then the edges touching the node with
 				object ``nobj`` are iterated over.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator adds object associated with the edge
 			 	into the tuple returned (e.g., ``(u,v,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator adds the weight of the edge
 				into the tuple returned (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the value of the ``data`` argument).
-				
+
 		Consider the following code which shows some of the different usages::
-		
+
 			G = DiGraph()
 			G.add_edge(1,2,data='e1')
 			G.add_edge(2,3,data='e2')
 			G.add_edge(3,1,data='e3')
-		
+
 			print len(list(G.edges_iter())) # this prints 3 - there are 3 edges in the graph
 			print len(list(G.edges_iter(1))) # this prints 2 - there are 2 edges attached to node 1
-			
+
 			# this will print the endpoints and data for all edges in the graph
 			for u,v,data in G.edges_iter(data=True):
 				print u,v,data
-				
+
 			# this will print the endpoints and data for all edges in the graph
 			for u,v,w in G.edges_iter(weight=True):
-				print u,v,data
+				print u,v,w
 		"""
 		if nobj is None:
 			return AllEdgeIterator(self,weight,data,True)
 		else:
 			return NodeEdgeIterator(self,self.node_idx_lookup[nobj],ITER_BOTH,weight,data,True)
-	
+
 	cpdef edges_iter_(DiGraph self,int nidx=-1,data=False,weight=False):
 		"""
 		Return an iterator over edges in the graph.
-		
+
 		By default, the iterator will cover all edges in the graph, returning each
 		edge as the edge index.
-		
+
 		**Args**:
-			
-			* ``nidx [=-1]`` (int): if ``nidx`` is specified (``>= 0``), then the edges touching the node with 
+
+			* ``nidx [=-1]`` (int): if ``nidx`` is specified (``>= 0``), then the edges touching the node with
 				index ``nidx`` are iterated over.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator returns a tuple containing the edge index
 				and the data associated with the edge (e.g., ``(eidx,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator 	returns a tuple containing the edge index
 				and the weight of the edge (e.g., ``(eidx,w)`` or ``(eidx,d,w)`` depending on the value of the ``data`` argument).
-					
+
 		Consider the following code which shows some of the different usages::
-	
+
 			G = DiGraph()
 			G.add_edge(1,2,data='e1')
 			G.add_edge(2,3,data='e2')
 			G.add_edge(3,1,data='e3')
-	
+
 			print len(list(G.edges_iter_())) # this prints 3 - there are 3 edges in the graph
 			print len(list(G.edges_iter_(G.node_idx(1)))) # this prints 2 - there are 2 edges attached to node 1
-		
+
 			# this will print the endpoints and data for all edges in the graph
 			for eidx,data in G.edges_iter_(data=True):
 				print eidx,data
-				
+
 			# this will print the endpoints and data for all edges in the graph
 			for eidx,w in G.edges_iter_(weight=True):
-				print eidx,w					
+				print eidx,w
 		"""
 		if nidx == -1:
 			return AllEdgeIterator(self,weight,data,False)
 		else:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 			return NodeEdgeIterator(self,nidx,ITER_BOTH,weight,data,False)
-	
+
 	cpdef edges(DiGraph self,nobj=None,data=False,weight=False):
 		"""
 		Return a list of edges in the graph.
-	
+
 		By default, the list will contain all edges in the graph, each
 		edge as the tuple ``(u,v)``, where ``u`` and ``v`` are (node object) endpoints of the edge.
-	
+
 		**Args**:
-		
-			* ``nobj [=None]``: if ``nobj`` is specified (not ``None``), then only the edges touching the node with 
+
+			* ``nobj [=None]``: if ``nobj`` is specified (not ``None``), then only the edges touching the node with
 				object ``nobj`` are included in the list.
-	
+
 			* ``data [=False]`` (boolean): if ``True``, then the data object associated with the edge
 			 	is added into the tuple returned for each edge (e.g., ``(u,v,d)``).
-	
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the weight of the edge is added
-				into the tuple returned for each edge (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the 
+				into the tuple returned for each edge (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the
 				value of the ``data`` argument).
-			
+
 		Consider the following code which shows some of the different usages::
-	
+
 			G = DiGraph()
 			G.add_edge(1,2,data='e1')
 			G.add_edge(2,3,data='e2')
 			G.add_edge(3,1,data='e3')
-	
+
 			print len(G.edges()) # this prints 3 - there are 3 edges in the graph
 			print len(G.edges(1)) # this prints 2 - there are 2 edges attached to node 1
-		
+
 			# this will print the endpoints and data for all edges in the graph
 			for u,v,data in G.edges(data=True):
 				print u,v,data
-			
+
 			# this will print the endpoints and data for all edges in the graph
 			for u,v,w in G.edges(weight=True):
-				print u,v,data
+				print u,v,w
 		"""
 		cdef int num_edges
 		cdef int* elist
 		cdef int i
 		cdef nidx = -1
 		cdef nidx2 = -1
-		
+
 		if nobj is not None:
 			nidx = self.node_idx_lookup[nobj]
-		
+
 		# iterate over all edges
 		result = []
 		if nidx == -1:
@@ -2100,7 +2100,7 @@ cdef class DiGraph:
 				if self.edge_info[i].exists:
 					if self.edge_info[i].src not in self.node_obj_lookup or self.edge_info[i].tgt not in self.node_obj_lookup:
 						raise ZenException, 'Edge (idx=%d) does not have endpoints with node objects' % i
-					
+
 					if data is True:
 						if weight is True:
 							result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_data_(i),self.edge_info[i].weight) )
@@ -2112,68 +2112,67 @@ cdef class DiGraph:
 						else:
 							result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt]) )
 					idx += 1
-					
+
 			return result
 		else:
-			idx = 0
 			num_edges = self.node_info[nidx].indegree
 			elist = self.node_info[nidx].inelist
 			for i in range(num_edges):
-				if self.edge_info[i].src not in self.node_obj_lookup or self.edge_info[i].tgt not in self.node_obj_lookup:
-					raise ZenException, 'Edge (idx=%d) does not have endpoints with node objects' % i
-					
+				idx = elist[i]
+				if self.edge_info[idx].src not in self.node_obj_lookup or self.edge_info[idx].tgt not in self.node_obj_lookup:
+					raise ZenException, 'Edge (idx=%d) does not have endpoints with node objects' % idx
+
 				if data is True:
 					if weight is True:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_data_(i),self.edge_info[i].weight) )
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt],self.edge_data_(idx),self.edge_info[idx].weight) )
 					else:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_data_(i)) )
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt],self.edge_data_(idx)) )
 				else:
 					if weight is True:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_info[i].weight) )
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt],self.edge_info[idx].weight) )
 					else:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt]) )
-				idx += 1
-			
-			# loop over out edges - this is copied verbatim from out_edges_iter(...)			
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt]) )
+
+			# loop over out edges - this is copied verbatim from out_edges_iter(...)
 			num_edges = self.node_info[nidx].outdegree
 			elist = self.node_info[nidx].outelist
 			for i in range(num_edges):
-				if self.edge_info[i].src not in self.node_obj_lookup or self.edge_info[i].tgt not in self.node_obj_lookup:
-					raise ZenException, 'Edge (idx=%d) does not have endpoints with node objects' % i
-					
+				idx = elist[i]
+				if self.edge_info[idx].src not in self.node_obj_lookup or self.edge_info[idx].tgt not in self.node_obj_lookup:
+					raise ZenException, 'Edge (idx=%d) does not have endpoints with node objects' % idx
+
 				if data is True:
 					if weight is True:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_data_(i),self.edge_info[i].weight) )
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt],self.edge_data_(idx),self.edge_info[idx].weight) )
 					else:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_data_(i)) )
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt],self.edge_data_(idx)) )
 				else:
 					if weight is True:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt],self.edge_info[i].weight) )
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt],self.edge_info[idx].weight) )
 					else:
-						result.append( (self.node_obj_lookup[self.edge_info[i].src],self.node_obj_lookup[self.edge_info[i].tgt]) )
-				idx += 1
-			
+						result.append( (self.node_obj_lookup[self.edge_info[idx].src],self.node_obj_lookup[self.edge_info[idx].tgt]) )
+
 			return result
-				
+
 	cpdef edges_(DiGraph self,int nidx=-1,data=False,weight=False):
 		"""
 		Return a ``numpy.ndarray`` containing edges in the graph.
-	
+
 		By default, the return value is a 1D array, ``R``, that contains all edges in the graph, where ``R[i]`` is
 		an edge index.
-	
+
 		**Args**:
-		
-			* ``nidx [=-1]`` (int): if ``nidx`` is specified (``>= 0``), then only the edges touching the node with 
+
+			* ``nidx [=-1]`` (int): if ``nidx`` is specified (``>= 0``), then only the edges touching the node with
 				index ``nidx`` are included in the array returned.
-	
+
 			* ``data [=False]`` (boolean): if ``True``, then the array will no longer be a 1D array.  A separate column will be added
 			 	such that ``R[i,0]`` is the edge index and ``R[i,1]`` is the data object associated with the edge.
-	
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the array will no longer be a 1D array.  A separate column will be added
 				such that ``R[i,0]`` is the edge index and ``R[i,1]`` is the weight of the edge.
-				
-		When additional columns are added, they will always be in the order edge index, data, weight. 
+
+		When additional columns are added, they will always be in the order edge index, data, weight.
 		Consider the following code which shows some of the different usages::
 
 			G = DiGraph()
@@ -2183,7 +2182,7 @@ cdef class DiGraph:
 
 			print G.edges_().shape # this prints (3,) - there are 3 edges in the graph and 1 column
 			print G.edges_(G.node_idx(1)).shape # this prints (2,) - there are 2 edges attached to node 1
-	
+
 			# this will print the endpoints and data for all edges in the graph
 			print G.edges_(data=True).shape # this prints (3,2)
 			print G.edges_(weight=True).shape # this prints (3,2)
@@ -2191,11 +2190,11 @@ cdef class DiGraph:
 		"""
 		if nidx != -1 and (nidx >= self.node_capacity or not self.node_info[nidx].exists):
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		cdef int num_edges
 		cdef int* elist
 		cdef int i
-		
+
 		# iterate over all edges
 		result = None
 		if nidx == -1:
@@ -2205,7 +2204,7 @@ cdef class DiGraph:
 				result = numpy.empty( (self.num_edges, 2), dtype=numpy.object_)
 			else:
 				result = numpy.empty(self.num_edges, dtype=numpy.object_)
-				
+
 			idx = 0
 			for i in range(self.next_edge_idx):
 				if self.edge_info[i].exists:
@@ -2224,14 +2223,14 @@ cdef class DiGraph:
 						else:
 							result[idx] = i
 					idx += 1
-					
+
 			return result
 		else:
 			if data:
 				result = numpy.empty( (self.node_info[nidx].indegree + self.node_info[nidx].outdegree,2), dtype=numpy.object_)
 			else:
 				result = numpy.empty(self.node_info[nidx].indegree + self.node_info[nidx].outdegree, dtype=numpy.object_)
-			
+
 			idx = 0
 			num_edges = self.node_info[nidx].indegree
 			elist = self.node_info[nidx].inelist
@@ -2251,8 +2250,8 @@ cdef class DiGraph:
 					else:
 						result[idx] = elist[i]
 				idx += 1
-			
-			# loop over out edges - this is copied verbatim from out_edges_iter(...)			
+
+			# loop over out edges - this is copied verbatim from out_edges_iter(...)
 			num_edges = self.node_info[nidx].outdegree
 			elist = self.node_info[nidx].outelist
 			for i in range(num_edges):
@@ -2271,23 +2270,23 @@ cdef class DiGraph:
 					else:
 						result[idx] = elist[i]
 				idx += 1
-			
+
 			return result
-			
+
 	cpdef in_edges_iter(DiGraph self,nobj,data=False,weight=False):
 		"""
 		Return an iterator over the edges for which ``nobj`` is a target.
-		
-		By default, the iterator will yield each edge as the tuple ``(u,tgt)``, 
+
+		By default, the iterator will yield each edge as the tuple ``(u,tgt)``,
 		where ``u`` and ``nobj`` are (node object) endpoints of the edge.
-		
+
 		**Args**:
-			
+
 			* ``nobj``: the object identifying the node from which all edges iterated over terminate at.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator adds object associated with the edge
 			 	into the tuple returned (e.g., ``(u,v,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator adds the weight of the edge
 				into the tuple returned (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the value of the ``data`` argument).
 		"""
@@ -2296,40 +2295,40 @@ cdef class DiGraph:
 	cpdef in_edges_iter_(DiGraph self,int nidx,data=False,weight=False):
 		"""
 		Return an iterator over the edges for which ``nidx`` (a node index) is a source.
-		
+
 		By default, the iterator will yield each edge as the edge index.
-		
+
 		**Args**:
-			
+
 			* ``nidx`` (int): the index for the node that is the terminating node for edges yielded.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator returns a tuple containing the edge index
 				and the data associated with the edge (e.g., ``(eidx,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator 	returns a tuple containing the edge index
 				and the weight of the edge (e.g., ``(eidx,w)`` or ``(eidx,d,w)`` depending on the value of the ``data`` argument).
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		return NodeEdgeIterator(self,nidx,ITER_INDEGREE,weight,data)
-		
+
 	cpdef in_edges(DiGraph self,nobj,data=False,weight=False):
 		"""
 		Return a list of edges in the graph for which ``nobj`` (a node object) is a target.
-	
-		By default, the list will contain each edge as the tuple ``(u,nobj)``, 
+
+		By default, the list will contain each edge as the tuple ``(u,nobj)``,
 		where ``u`` and ``nobj`` are (node object) endpoints of the edge.
-	
+
 		**Args**:
-		
+
 			* ``nobj``: the object identifying the node from which all edges iterated over terminate at.
-	
+
 			* ``data [=False]`` (boolean): if ``True``, then the data object associated with the edge
 			 	is added into the tuple returned for each edge (e.g., ``(u,v,d)``).
-	
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the weight of the edge is added
-				into the tuple returned for each edge (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the 
+				into the tuple returned for each edge (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the
 				value of the ``data`` argument).
 		"""
 		return list(self.in_edges_iter(nobj,data,weight))
@@ -2337,70 +2336,70 @@ cdef class DiGraph:
 	cpdef in_edges_(DiGraph self,int nidx,data=False,weight=False):
 		"""
 		Return a ``numpy.ndarray`` containing edges in the graph that terminate at node with index ``nidx``.
-	
+
 		By default, the return value is a 1D array, ``R``, where ``R[i]`` is an edge index.
-	
+
 		**Args**:
-		
+
 			* ``nidx`` (int): the index for the node at which the edges included in the array terminate.
-	
+
 			* ``data [=False]`` (boolean): if ``True``, then the array will no longer be a 1D array.  A separate column will be added
 			 	such that ``R[i,0]`` is the edge index and ``R[i,1]`` is the data object associated with the edge.
-	
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the array will no longer be a 1D array.  A separate column will be added
 				such that ``R[i,0]`` is the edge index and ``R[i,1]`` is the weight of the edge.
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		cdef int i
 		cdef int* elist
 		cdef int indegree
 		result = None
 		elist = self.node_info[nidx].inelist
 		indegree = self.node_info[nidx].indegree
-		
+
 		if data and weight:
 			result = numpy.empty( (indegree,3), dtype=numpy.object_)
-			
+
 			for i in range(indegree):
 				result[i,0] = elist[i]
 				result[i,1] = self.edge_data_lookup.get(elist[i],None)
 				result[i,2] = self.edge_info[elist[i]].weight
 		elif data:
 			result = numpy.empty( (indegree,2), dtype=numpy.object_)
-			
+
 			for i in range(indegree):
 				result[i,0] = elist[i]
 				result[i,1] = self.edge_data_lookup.get(elist[i],None)
 		elif weight:
 			result = numpy.empty( (indegree,2), dtype=numpy.object_)
-			
+
 			for i in range(indegree):
 				result[i,0] = elist[i]
 				result[i,1] = self.edge_info[elist[i]].weight
 		else:
 			result = numpy.empty(indegree, dtype=numpy.int)
-			
+
 			for i in range(indegree):
 				result[i] = elist[i]
-				
+
 		return result
-		
+
 	cpdef out_edges_iter(DiGraph self,nobj,data=False,weight=False):
 		"""
 		Return an iterator over the edges for which ``nobj`` is a source.
-		
-		By default, the iterator will yield each edge as the tuple ``(nobj,v)``, 
+
+		By default, the iterator will yield each edge as the tuple ``(nobj,v)``,
 		where ``nobj`` and ``v`` are (node object) endpoints of the edge.
-		
+
 		**Args**:
-			
+
 			* ``nobj``: the object identifying the node from which all edges iterated over eminate from.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator adds object associated with the edge
 			 	into the tuple returned (e.g., ``(u,v,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator adds the weight of the edge
 				into the tuple returned (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the value of the ``data`` argument).
 		"""
@@ -2409,40 +2408,40 @@ cdef class DiGraph:
 	cpdef out_edges_iter_(DiGraph self,int nidx,data=False,weight=False):
 		"""
 		Return an iterator over the edges for which ``nidx`` (a node index) is a source.
-		
+
 		By default, the iterator will yield each edge as the edge index.
-		
+
 		**Args**:
-			
+
 			* ``nidx`` (int): the index for the node that is the originating node for edges yielded.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator returns a tuple containing the edge index
 				and the data associated with the edge (e.g., ``(eidx,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator 	returns a tuple containing the edge index
 				and the weight of the edge (e.g., ``(eidx,w)`` or ``(eidx,d,w)`` depending on the value of the ``data`` argument).
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		return NodeEdgeIterator(self,nidx,ITER_OUTDEGREE,weight,data)
-	
+
 	cpdef out_edges(DiGraph self,nobj,data=False,weight=False):
 		"""
 		Return a list of edges in the graph for which ``nobj`` (a node object) is a source.
-	
-		By default, the list will contain each edge as the tuple ``(nobj,v)``, 
+
+		By default, the list will contain each edge as the tuple ``(nobj,v)``,
 		where ``nobj`` and ``v`` are (node object) endpoints of the edge.
-	
+
 		**Args**:
-		
+
 			* ``nobj``: the object identifying the node from which all edges iterated over originate at.
-	
+
 			* ``data [=False]`` (boolean): if ``True``, then the data object associated with the edge
 			 	is added into the tuple returned for each edge (e.g., ``(u,v,d)``).
-	
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the weight of the edge is added
-				into the tuple returned for each edge (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the 
+				into the tuple returned for each edge (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the
 				value of the ``data`` argument).
 		"""
 		return list(self.out_edges_iter(nobj,data,weight))
@@ -2450,68 +2449,68 @@ cdef class DiGraph:
 	cpdef out_edges_(DiGraph self,int nidx,data=False,weight=False):
 		"""
 		Return a ``numpy.ndarray`` containing edges in the graph that originate at node with index ``nidx``.
-	
+
 		By default, the return value is a 1D array, ``R``, where ``R[i]`` is an edge index.
-	
+
 		**Args**:
-		
+
 			* ``nidx`` (int): the index for the node at which the edges included in the array originate.
-	
+
 			* ``data [=False]`` (boolean): if ``True``, then the array will no longer be a 1D array.  A separate column will be added
 			 	such that ``R[i,0]`` is the edge index and ``R[i,1]`` is the data object associated with the edge.
-	
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the array will no longer be a 1D array.  A separate column will be added
 				such that ``R[i,0]`` is the edge index and ``R[i,1]`` is the weight of the edge.
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		cdef int i
 		cdef int* elist
 		cdef int outdegree
-		
+
 		result = None
 		elist = self.node_info[nidx].outelist
 		outdegree = self.node_info[nidx].outdegree
-		
+
 		if data and weight:
 			result = numpy.empty( (outdegree,3), dtype=numpy.object_)
-			
+
 			for i in range(outdegree):
 				result[i,0] = elist[i]
 				result[i,1] = self.edge_data_lookup.get(elist[i],None)
 				result[i,2] = self.edge_info[elist[i]].weight
 		elif data:
 			result = numpy.empty( (outdegree,2), dtype=numpy.object_)
-			
+
 			for i in range(outdegree):
 				result[i,0] = elist[i]
 				result[i,1] = self.edge_data_lookup.get(elist[i],None)
 		elif weight:
 			result = numpy.empty( (outdegree,2), dtype=numpy.object_)
-			
+
 			for i in range(outdegree):
 				result[i,0] = elist[i]
 				result[i,1] = self.edge_info[elist[i]].weight
 		else:
 			result = numpy.empty(outdegree, dtype=numpy.int)
-			
+
 			for i in range(outdegree):
 				result[i] = elist[i]
 
 		return result
-	
+
 	cpdef grp_edges_iter(DiGraph self,nbunch,data=False,weight=False):
 		"""
-		Return an iterator over the edges of a group of nodes.  
-		
+		Return an iterator over the edges of a group of nodes.
+
 		By default, the iterator will return each edge as the tuple ``(u,v)``, where ``u`` and ``v`` are (node object) endpoints of the edge.
-		
+
 		**Args**:
-		
+
 			* ``nbunch``: an iterable (usually a list) that yields node objects.  These are
 				the nodes whose incident edges the iterator will return.
-			
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator adds object associated with the edge
 			 	into the tuple returned (e.g., ``(u,v,d)``).
 
@@ -2522,15 +2521,15 @@ cdef class DiGraph:
 
 	cpdef grp_in_edges_iter(DiGraph self,nbunch,data=False,weight=False):
 		"""
-		Return an iterator over the edges that terminate within a group of nodes.  
-		
+		Return an iterator over the edges that terminate within a group of nodes.
+
 		By default, the iterator will return each edge as the tuple ``(u,v)``, where ``u`` and ``v`` are (node object) endpoints of the edge.
-		
+
 		**Args**:
-		
+
 			* ``nbunch``: an iterable (usually a list) that yields node objects.  These are
 				the nodes whose terminal edges the iterator will return.
-			
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator adds object associated with the edge
 			 	into the tuple returned (e.g., ``(u,v,d)``).
 
@@ -2541,15 +2540,15 @@ cdef class DiGraph:
 
 	cpdef grp_out_edges_iter(DiGraph self,nbunch,data=False,weight=False):
 		"""
-		Return an iterator over the edges that originate within a group of nodes.  
-		
+		Return an iterator over the edges that originate within a group of nodes.
+
 		By default, the iterator will return each edge as the tuple ``(u,v)``, where ``u`` and ``v`` are (node object) endpoints of the edge.
-		
+
 		**Args**:
-		
+
 			* ``nbunch``: an iterable (usually a list) that yields node objects.  These are
 				the nodes whose originating edges the iterator will return.
-			
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator adds object associated with the edge
 			 	into the tuple returned (e.g., ``(u,v,d)``).
 
@@ -2557,76 +2556,76 @@ cdef class DiGraph:
 				into the tuple returned (e.g., ``(u,v,w)`` or ``(u,v,data,w)`` depending on the value of the ``data`` argument).
 		"""
 		return SomeEdgeIterator(self,[self.node_idx_lookup[x] for x in nbunch],ITER_OUTDEGREE,weight,data,True)
-		
+
 	cpdef grp_edges_iter_(DiGraph self,nbunch,data=False,weight=False):
 		"""
 		Return an iterator over edges incident to some nodes in the graph.
-		
+
 		By default, the iterator will return each edge as the edge index.
-		
+
 		**Args**:
-			
+
 			* ``nbunch``: an iterable (usually a list) that yields node indices.  These are
 				the nodes whose originating edges the iterator will return.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator returns a tuple containing the edge index
 				and the data associated with the edge (e.g., ``(eidx,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator 	returns a tuple containing the edge index
 				and the weight of the edge (e.g., ``(eidx,w)`` or ``(eidx,d,w)`` depending on the value of the ``data`` argument).
 		"""
 		for nidx in nbunch:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		return SomeEdgeIterator(self,nbunch,ITER_BOTH,weight,data)
 
 	cpdef grp_in_edges_iter_(DiGraph self,nbunch,data=False,weight=False):
 		"""
 		Return an iterator over edges that terminate among some nodes in the graph.
-		
+
 		By default, the iterator will return each edge as the edge index.
-		
+
 		**Args**:
-			
+
 			* ``nbunch``: an iterable (usually a list) that yields node indices.  These are
 				the nodes among whom the edges returned terminate.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator returns a tuple containing the edge index
 				and the data associated with the edge (e.g., ``(eidx,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator 	returns a tuple containing the edge index
 				and the weight of the edge (e.g., ``(eidx,w)`` or ``(eidx,d,w)`` depending on the value of the ``data`` argument).
 		"""
 		for nidx in nbunch:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		return SomeEdgeIterator(self,nbunch,ITER_INDEGREE,weight,data)
 
 	cpdef grp_out_edges_iter_(DiGraph self,nbunch,data=False,weight=False):
 		"""
 		Return an iterator over edges that originate among some nodes in the graph.
-		
+
 		By default, the iterator will return each edge as the edge index.
-		
+
 		**Args**:
-			
+
 			* ``nbunch``: an iterable (usually a list) that yields node indices.  These are
 				the nodes among whom the edges returned originate.
-		
+
 			* ``data [=False]`` (boolean): if ``True``, then the iterator returns a tuple containing the edge index
 				and the data associated with the edge (e.g., ``(eidx,d)``).
-		
+
 			* ``weight [=False]`` (boolean): 	if ``True``, then the iterator 	returns a tuple containing the edge index
 				and the weight of the edge (e.g., ``(eidx,w)`` or ``(eidx,d,w)`` depending on the value of the ``data`` argument).
 		"""
 		for nidx in nbunch:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		return SomeEdgeIterator(self,nbunch,ITER_OUTDEGREE,weight,data)
-						
+
 	cpdef neighbors(DiGraph self,nobj,data=False):
 		"""
 		Return a list of a node's immediate neighbors.
@@ -2634,7 +2633,7 @@ cdef class DiGraph:
 		By default, the list will contain the node object for each immediate neighbor of ``nobj``.
 
 		**Args**:
-	
+
 			* ``nobj``: this is the node object identifying the node whose neighbors to retrieve.
 
 			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned containing the node
@@ -2644,21 +2643,21 @@ cdef class DiGraph:
 		cdef int* elist
 		cdef int rid
 		cdef nidx = self.node_idx_lookup[nobj]
-		
+
 		visited_neighbors = set()
 
 		result = []
 		idx = 0
-		
+
 		# loop over in edges
 		num_edges = self.node_info[nidx].indegree
 		elist = self.node_info[nidx].inelist
 		for i in range(num_edges):
 			rid = self.edge_info[elist[i]].src
-			
+
 			if rid in visited_neighbors:
 				continue
-			
+
 			if data is True:
 				result.append( (self.node_obj_lookup[rid], self.node_data_lookup[rid]) )
 			else:
@@ -2666,18 +2665,18 @@ cdef class DiGraph:
 					raise ZenException, 'No node lookup known for node %d' % rid
 				result.append(self.node_obj_lookup[rid])
 			visited_neighbors.add(rid)
-			
+
 			idx += 1
-			
+
 		# loop over out edges
 		num_edges = self.node_info[nidx].outdegree
 		elist = self.node_info[nidx].outelist
 		for i in range(num_edges):
 			rid = self.edge_info[elist[i]].tgt
-			
+
 			if rid in visited_neighbors:
 				continue
-			
+
 			if data is True:
 				result.append( (self.node_obj_lookup[rid], self.node_data_lookup[rid]) )
 			else:
@@ -2685,11 +2684,11 @@ cdef class DiGraph:
 					raise ZenException, 'No node lookup known for node %d' % rid
 				result.append(self.node_obj_lookup[rid])
 			visited_neighbors.add(rid)
-			
+
 			idx += 1
-			
+
 		return result
-		
+
 	cpdef neighbors_(DiGraph self,int nidx,obj=False,data=False):
 		"""
 		Return an ``numpy.ndarray`` containing a node's immediate neighbors.
@@ -2709,33 +2708,33 @@ cdef class DiGraph:
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		cdef int num_edges
 		cdef int* elist
 		cdef int rid
-		
+
 		visited_neighbors = set()
-		
+
 		result = None
 		if obj or data:
 			ndim = 1 if not data and not obj else (2 if not data or not obj else 3)
 			result = numpy.empty( (self.node_info[nidx].indegree + self.node_info[nidx].outdegree,ndim), dtype=numpy.object_)
 		else:
 			result = numpy.empty( self.node_info[nidx].indegree + self.node_info[nidx].outdegree, dtype=numpy.object_)
-		
+
 		idx = 0
-		
+
 		# loop over in edges
 		num_edges = self.node_info[nidx].indegree
 		elist = self.node_info[nidx].inelist
 		for i in range(num_edges):
 			rid = self.edge_info[elist[i]].src
-			
+
 			if rid in visited_neighbors:
 				continue
-				
+
 			visited_neighbors.add(rid)
-			
+
 			if not obj and not data:
 				result[idx] = rid
 			elif obj and not data:
@@ -2760,20 +2759,20 @@ cdef class DiGraph:
 					result[idx,2] = self.node_data_lookup[rid]
 				else:
 					result[idx,2] = None
-				
+
 			idx += 1
-			
+
 		# loop over out edges
 		num_edges = self.node_info[nidx].outdegree
 		elist = self.node_info[nidx].outelist
 		for i in range(num_edges):
 			rid = self.edge_info[elist[i]].tgt
-			
+
 			if rid in visited_neighbors:
 				continue
-				
+
 			visited_neighbors.add(rid)
-			
+
 			if not obj and not data:
 				result[idx] = rid
 			elif obj and not data:
@@ -2799,14 +2798,14 @@ cdef class DiGraph:
 				else:
 					result[idx,2] = None
 			idx += 1
-			
+
 		if data:
 			result.resize( (idx,2) )
 		else:
 			result.resize(idx)
-			
+
 		return result
-		
+
 	cpdef neighbors_iter(DiGraph self,nobj,data=False):
 		"""
 		Return an iterator over a node's immediate neighbors.
@@ -2817,11 +2816,11 @@ cdef class DiGraph:
 
 			* ``nobj``: this is the node object identifying the node whose neighbors to iterate over.
 
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node object) 
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node object)
 				containing the node	object and the data object associated with the node (e.g., ``(n,d)``).
 		"""
 		return NeighborIterator(self,self.node_idx_lookup[nobj],ITER_BOTH,False,data,True)
-		
+
 	cpdef neighbors_iter_(DiGraph self,int nidx,obj=False,data=False):
 		"""
 		Return an iterator over a node's immediate neighbors.
@@ -2832,18 +2831,18 @@ cdef class DiGraph:
 
 			* ``nidx``: this is the node index identifying the node whose neighbors to iterate over.
 
-			* ``obj [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index) 
+			* ``obj [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index)
 				containing the node	index and the node object associated with the node (e.g., ``(nidx,n)``).
-				
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index) 
+
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index)
 				containing the node	index and the data object associated with the node (e.g., ``(nidx,d)`` or ``(nidx,n,d)``
 				depending on the value of the ``nobj`` argument).
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		return NeighborIterator(self,nidx,ITER_BOTH,obj,data,False)
-		
+
 	cpdef in_neighbors_iter(DiGraph self,nobj,data=False):
 		"""
 		Return an iterator over a node's immediate in-bound neighbors.
@@ -2854,11 +2853,11 @@ cdef class DiGraph:
 
 			* ``nobj``: this is the node object identifying the node whose in-bound neighbors to iterate over.
 
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node object) 
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node object)
 				containing the node	object and the data object associated with the node (e.g., ``(n,d)``).
 		"""
 		return NeighborIterator(self,self.node_idx_lookup[nobj],ITER_INDEGREE,False,data,True)
-		
+
 	cpdef in_neighbors_iter_(DiGraph self,int nidx,obj=False,data=False):
 		"""
 		Return an iterator over a node's immediate in-bound neighbors.
@@ -2869,16 +2868,16 @@ cdef class DiGraph:
 
 			* ``nidx``: this is the node index identifying the node whose in-bound neighbors to iterate over.
 
-			* ``obj [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index) 
+			* ``obj [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index)
 				containing the node	index and the node object associated with the node (e.g., ``(nidx,n)``).
-				
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index) 
+
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index)
 				containing the node	index and the data object associated with the node (e.g., ``(nidx,d)`` or ``(nidx,n,d)``
 				depending on the value of the ``nobj`` argument).
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		return NeighborIterator(self,nidx,ITER_INDEGREE,obj,data,False)
 
 	cpdef in_neighbors(DiGraph self,nobj,data=False):
@@ -2888,7 +2887,7 @@ cdef class DiGraph:
 		By default, the list will contain the node object for each immediate in-bound neighbor of ``nobj``.
 
 		**Args**:
-	
+
 			* ``nobj``: this is the node object identifying the node whose in-bound neighbors to retrieve.
 
 			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned containing the node
@@ -2915,7 +2914,7 @@ cdef class DiGraph:
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		cdef int i
 		cdef int* elist
 		cdef int indegree
@@ -2960,11 +2959,11 @@ cdef class DiGraph:
 
 			* ``nobj``: this is the node object identifying the node whose out-bound neighbors to iterate over.
 
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node object) 
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node object)
 				containing the node	object and the data object associated with the node (e.g., ``(n,d)``).
 		"""
 		return NeighborIterator(self,self.node_idx_lookup[nobj],ITER_OUTDEGREE,False,data,True)
-		
+
 	cpdef out_neighbors_iter_(DiGraph self,int nidx,obj=False,data=False):
 		"""
 		Return an iterator over a node's immediate out-bound neighbors.
@@ -2975,16 +2974,16 @@ cdef class DiGraph:
 
 			* ``nidx``: this is the node index identifying the node whose out-bound neighbors to iterate over.
 
-			* ``obj [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index) 
+			* ``obj [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index)
 				containing the node	index and the node object associated with the node (e.g., ``(nidx,n)``).
-				
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index) 
+
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned (rather than a node index)
 				containing the node	index and the data object associated with the node (e.g., ``(nidx,d)`` or ``(nidx,n,d)``
 				depending on the value of the ``nobj`` argument).
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		return NeighborIterator(self,nidx,ITER_OUTDEGREE,obj,data,False)
 
 	cpdef out_neighbors(DiGraph self,nobj,data=False):
@@ -2994,7 +2993,7 @@ cdef class DiGraph:
 		By default, the list will contain the node object for each immediate out-bound neighbor of ``nobj``.
 
 		**Args**:
-	
+
 			* ``nobj``: this is the node object identifying the node whose out-bound neighbors to retrieve.
 
 			* ``data [=False]`` (boolean): if ``True``, then a tuple is returned containing the node
@@ -3021,7 +3020,7 @@ cdef class DiGraph:
 		"""
 		if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 			raise ZenException, 'Invalid node idx %d' % nidx
-			
+
 		cdef int i
 		cdef int* elist
 		cdef int outdegree
@@ -3055,7 +3054,7 @@ cdef class DiGraph:
 				result[i] = self.edge_info[elist[i]].tgt
 
 		return result
-			
+
 	cpdef grp_neighbors_iter(DiGraph self,nbunch,data=False):
 		"""
 		Return an iterator over a group of nodes' immediate neighbors.
@@ -3066,7 +3065,7 @@ cdef class DiGraph:
 
 			* ``nbunch``: an iterable providing the node object over whose neighbors to iterate.
 
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node object) 
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node object)
 				containing the node	object and the data object associated with the node (e.g., ``(n,d)``).
 		"""
 		return SomeNeighborIterator(self,[self.node_idx_lookup[x] for x in nbunch],ITER_BOTH,False,data,True)
@@ -3081,7 +3080,7 @@ cdef class DiGraph:
 
 			* ``nbunch``: an iterable providing the node object over whose in-bound neighbors to iterate.
 
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node object) 
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node object)
 				containing the node	object and the data object associated with the node (e.g., ``(n,d)``).
 		"""
 		return SomeNeighborIterator(self,[self.node_idx_lookup[x] for x in nbunch],ITER_INDEGREE,False,data,True)
@@ -3096,7 +3095,7 @@ cdef class DiGraph:
 
 			* ``nbunch``: an iterable providing the node object over whose out-bound neighbors to iterate.
 
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node object) 
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node object)
 				containing the node	object and the data object associated with the node (e.g., ``(n,d)``).
 		"""
 		return SomeNeighborIterator(self,[self.node_idx_lookup[x] for x in nbunch],ITER_OUTDEGREE,False,data,True)
@@ -3111,17 +3110,17 @@ cdef class DiGraph:
 
 			* ``nbunch``: an iterable providing the node indices over whose neighbors to iterate.
 
-			* ``obj [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index) 
+			* ``obj [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index)
 				containing the node	index and the node object associated with the node (e.g., ``(nidx,n)``).
-			
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index) 
+
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index)
 				containing the node	index and the data object associated with the node (e.g., ``(nidx,d)`` or ``(nidx,n,d)``
 				depending on the value of the ``nobj`` argument).
 		"""
 		for nidx in nbunch:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		return SomeNeighborIterator(self,nbunch,ITER_BOTH,obj,data,False)
 
 	cpdef grp_in_neighbors_iter_(DiGraph self,nbunch,obj=False,data=False):
@@ -3134,17 +3133,17 @@ cdef class DiGraph:
 
 			* ``nbunch``: an iterable providing the node indices over whose in-bound neighbors to iterate.
 
-			* ``obj [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index) 
+			* ``obj [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index)
 				containing the node	index and the node object associated with the node (e.g., ``(nidx,n)``).
-			
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index) 
+
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index)
 				containing the node	index and the data object associated with the node (e.g., ``(nidx,d)`` or ``(nidx,n,d)``
 				depending on the value of the ``nobj`` argument).
 		"""
 		for nidx in nbunch:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		return SomeNeighborIterator(self,nbunch,ITER_INDEGREE,obj,data,False)
 
 	cpdef grp_out_neighbors_iter_(DiGraph self,nbunch,obj=False,data=False):
@@ -3157,19 +3156,19 @@ cdef class DiGraph:
 
 			* ``nbunch``: an iterable providing the node indices over whose out-bound neighbors to iterate.
 
-			* ``obj [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index) 
+			* ``obj [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index)
 				containing the node	index and the node object associated with the node (e.g., ``(nidx,n)``).
-			
-			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index) 
+
+			* ``data [=False]`` (boolean): if ``True``, then a tuple is yielded (rather than a node index)
 				containing the node	index and the data object associated with the node (e.g., ``(nidx,d)`` or ``(nidx,n,d)``
 				depending on the value of the ``nobj`` argument).
 		"""
 		for nidx in nbunch:
 			if nidx >= self.node_capacity or not self.node_info[nidx].exists:
 				raise ZenException, 'Invalid node idx %d' % nidx
-				
+
 		return SomeNeighborIterator(self,nbunch,ITER_OUTDEGREE,obj,data,False)
-								
+
 cdef class NodeIterator:
 	cdef bint data
 	cdef DiGraph graph
@@ -3178,7 +3177,7 @@ cdef class NodeIterator:
 	cdef bint nobj
 	cdef bint obj
 	cdef long init_num_changes
-	
+
 	def __cinit__(NodeIterator self,DiGraph graph,bint obj,bint data,bint nobj):
 		self.init_num_changes = graph.num_changes
 		self.data = data
@@ -3191,7 +3190,7 @@ cdef class NodeIterator:
 	def __next__(NodeIterator self):
 		if self.init_num_changes != self.graph.num_changes:
 			raise GraphChangedException()
-		
+
 		if self.node_count >= self.graph.num_nodes:
 			raise StopIteration()
 
@@ -3225,7 +3224,7 @@ cdef class NodeIterator:
 				obj = self.graph.node_obj_lookup[idx]
 			if self.data and idx in self.graph.node_data_lookup:
 				data = self.graph.node_data_lookup[idx]
-				
+
 			if not self.obj and not self.data:
 				return idx
 			elif self.obj and not self.data:
@@ -3237,7 +3236,7 @@ cdef class NodeIterator:
 
 	def __iter__(NodeIterator self):
 		return self
-		
+
 cdef class AllEdgeIterator:
 	cdef bint data
 	cdef bint weight
@@ -3245,7 +3244,7 @@ cdef class AllEdgeIterator:
 	cdef int idx
 	cdef bint endpoints
 	cdef long init_num_changes
-	
+
 	def __cinit__(AllEdgeIterator self,DiGraph graph,weight=False,data=False,endpoints=False):
 		self.init_num_changes = graph.num_changes
 		self.graph = graph
@@ -3253,29 +3252,29 @@ cdef class AllEdgeIterator:
 		self.weight = weight
 		self.idx = 0
 		self.endpoints = endpoints
-		
+
 	def __next__(AllEdgeIterator self):
 		if self.init_num_changes != self.graph.num_changes:
 			raise GraphChangedException()
-			
+
 		cdef int idx = self.idx
-		
+
 		if idx == self.graph.next_edge_idx:
 			raise StopIteration()
-		
+
 		while idx < self.graph.next_edge_idx and not self.graph.edge_info[idx].exists:
 			idx += 1
 
 		if idx >= self.graph.next_edge_idx:
 			self.idx = idx
 			raise StopIteration()
-			
+
 		self.idx = idx + 1
 		if self.weight and self.data:
 			val = None
 			if idx in self.graph.edge_data_lookup:
 				val = self.graph.edge_data_lookup[idx]
-				
+
 			if not self.endpoints:
 				return idx, val, self.graph.edge_info[idx].weight
 			else:
@@ -3283,7 +3282,7 @@ cdef class AllEdgeIterator:
 					raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 				elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 					raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-					
+
 				return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], val, self.graph.edge_info[idx].weight
 		elif self.weight:
 			if not self.endpoints:
@@ -3293,7 +3292,7 @@ cdef class AllEdgeIterator:
 					raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 				elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 					raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-					
+
 				return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], self.graph.edge_info[idx].weight
 		elif self.data:
 			val = None
@@ -3306,7 +3305,7 @@ cdef class AllEdgeIterator:
 					raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 				elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 					raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-					
+
 				return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], val
 		else:
 			if not self.endpoints:
@@ -3316,7 +3315,7 @@ cdef class AllEdgeIterator:
 					raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 				elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 					raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-					
+
 				return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt]
 
 	def __iter__(AllEdgeIterator self):
@@ -3325,7 +3324,7 @@ cdef class AllEdgeIterator:
 cdef int ITER_BOTH = 0
 cdef int ITER_INDEGREE = 1
 cdef int ITER_OUTDEGREE = 2
-		
+
 cdef class NodeEdgeIterator:
 	cdef bint data
 	cdef bint weight
@@ -3336,7 +3335,7 @@ cdef class NodeEdgeIterator:
 	cdef int which_degree
 	cdef bint endpoints
 	cdef long init_num_changes
-	
+
 	def __cinit__(NodeEdgeIterator self,DiGraph graph,nidx,which_degree,weight=False,data=False,endpoints=False):
 		self.init_num_changes = graph.num_changes
 		self.graph = graph
@@ -3346,7 +3345,7 @@ cdef class NodeEdgeIterator:
 		self.idx = 0
 		self.which_degree = which_degree
 		self.endpoints = endpoints
-		
+
 		self.deg = 0
 		if self.which_degree == ITER_BOTH:
 			if self.graph.node_info[nidx].indegree > 0:
@@ -3357,14 +3356,14 @@ cdef class NodeEdgeIterator:
 			self.deg = 1
 		elif self.which_degree == ITER_OUTDEGREE and self.graph.node_info[nidx].outdegree > 0:
 			self.deg = 2
-			
+
 	def __next__(NodeEdgeIterator self):
 		if self.init_num_changes != self.graph.num_changes:
 			raise GraphChangedException()
-			
+
 		cdef int idx = self.idx
 		cdef int* elist
-		
+
 		if self.deg == 0:
 			raise StopIteration()
 		elif self.deg == 1:
@@ -3379,12 +3378,12 @@ cdef class NodeEdgeIterator:
 					self.deg = 0
 			else:
 				self.idx = idx + 1
-			
+
 			if self.weight and self.data:
 				val = None
 				if elist[idx] in self.graph.edge_data_lookup:
 					val = self.graph.edge_data_lookup[elist[idx]]
-					
+
 				idx = elist[idx]
 				if not self.endpoints:
 					return idx, val, self.graph.edge_info[idx].weight
@@ -3393,7 +3392,7 @@ cdef class NodeEdgeIterator:
 						raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 					elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 						raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-						
+
 					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], val, self.graph.edge_info[idx].weight
 			elif self.weight:
 				idx = elist[idx]
@@ -3404,8 +3403,8 @@ cdef class NodeEdgeIterator:
 						raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 					elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 						raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-						
-					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], self.graph.edge_info[idx].weight				
+
+					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], self.graph.edge_info[idx].weight
 			elif self.data:
 				val = None
 				if elist[idx] in self.graph.edge_data_lookup:
@@ -3418,7 +3417,7 @@ cdef class NodeEdgeIterator:
 						raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 					elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 						raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-						
+
 					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], val
 			else:
 				if not self.endpoints:
@@ -3429,9 +3428,9 @@ cdef class NodeEdgeIterator:
 						raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[idx].src
 					elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 						raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
-						
+
 					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt]
-				
+
 		elif self.deg == 2:
 			num_edges = self.graph.node_info[self.nidx].outdegree
 			elist = self.graph.node_info[self.nidx].outelist
@@ -3441,7 +3440,7 @@ cdef class NodeEdgeIterator:
 				self.deg = 0
 			else:
 				self.idx = idx + 1
-		
+
 			if self.weight and self.data:
 				val = None
 				if elist[idx] in self.graph.edge_data_lookup:
@@ -3467,7 +3466,7 @@ cdef class NodeEdgeIterator:
 					elif self.graph.edge_info[idx].tgt not in self.graph.node_obj_lookup:
 						raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[idx].tgt
 
-					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], self.graph.edge_info[idx].weight				
+					return self.graph.node_obj_lookup[self.graph.edge_info[idx].src], self.graph.node_obj_lookup[self.graph.edge_info[idx].tgt], self.graph.edge_info[idx].weight
 			elif self.data:
 				val = None
 				if elist[idx] in self.graph.edge_data_lookup:
@@ -3518,7 +3517,7 @@ cdef class SomeEdgeIterator:
 		self.edge_iter = None
 		self.touched_edges = set()
 		self.endpoints = endpoints
-		
+
 		# setup the first iterator
 		if len(nbunch) > 0:
 			curr_nidx = self.nbunch_iter.next()
@@ -3529,7 +3528,7 @@ cdef class SomeEdgeIterator:
 	def __next__(SomeEdgeIterator self):
 		if self.init_num_changes != self.graph.num_changes:
 			raise GraphChangedException()
-			
+
 		while True:
 			if self.edge_iter is None:
 				raise StopIteration
@@ -3540,7 +3539,7 @@ cdef class SomeEdgeIterator:
 						if result[0] in self.touched_edges:
 							continue
 						self.touched_edges.add(result[0])
-						
+
 						if not self.endpoints:
 							return result
 						else:
@@ -3548,13 +3547,13 @@ cdef class SomeEdgeIterator:
 								raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[result[0]].src
 							elif self.graph.edge_info[result[0]].tgt not in self.graph.node_obj_lookup:
 								raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[result[0]].tgt
-								
+
 							return self.graph.node_obj_lookup[self.graph.edge_info[result[0]].src], self.graph.node_obj_lookup[self.graph.edge_info[result[0]].tgt], result[1], result[2]
 					elif self.weight or self.data:
 						if result[0] in self.touched_edges:
 							continue
 						self.touched_edges.add(result[0])
-						
+
 						if not self.endpoints:
 							return result
 						else:
@@ -3562,13 +3561,13 @@ cdef class SomeEdgeIterator:
 								raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[result[0]].src
 							elif self.graph.edge_info[result[0]].tgt not in self.graph.node_obj_lookup:
 								raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[result[0]].tgt
-								
+
 							return self.graph.node_obj_lookup[self.graph.edge_info[result[0]].src], self.graph.node_obj_lookup[self.graph.edge_info[result[0]].tgt], result[1]
 					else:
 						if result in self.touched_edges:
 							continue
 						self.touched_edges.add(result)
-					
+
 						if not self.endpoints:
 							return result
 						else:
@@ -3576,7 +3575,7 @@ cdef class SomeEdgeIterator:
 								raise ZenException, 'Missing endpoint: Source node (idx=%d) does not have an object' % self.graph.edge_info[result].src
 							elif self.graph.edge_info[result].tgt not in self.graph.node_obj_lookup:
 								raise ZenException, 'Missing endpoint: Target node (idx=%d) does not have an object' % self.graph.edge_info[result].tgt
-								
+
 							return self.graph.node_obj_lookup[self.graph.edge_info[result].src], self.graph.node_obj_lookup[self.graph.edge_info[result].tgt]
 				except StopIteration:
 					self.edge_iter = None
@@ -3585,7 +3584,7 @@ cdef class SomeEdgeIterator:
 
 	def __iter__(SomeEdgeIterator self):
 		return self
-						
+
 cdef class NeighborIterator:
 	cdef NodeEdgeIterator inner_iter
 	cdef bint data
@@ -3596,7 +3595,7 @@ cdef class NeighborIterator:
 	cdef bint use_nobjs
 	cdef bint obj
 	cdef long init_num_changes
-	
+
 	def __cinit__(NeighborIterator self, DiGraph G, int nidx,which_degree,obj,data,use_nobjs):
 		self.init_num_changes = G.num_changes
 		self.inner_iter = NodeEdgeIterator(G,nidx,which_degree,False)
@@ -3607,18 +3606,18 @@ cdef class NeighborIterator:
 		self.touched_nodes = set()
 		self.use_nobjs = use_nobjs
 		self.obj = obj
-		
+
 	def __next__(NeighborIterator self):
 		if self.init_num_changes != self.G.num_changes:
 			raise GraphChangedException()
-		while True:		
+		while True:
 			eid = self.inner_iter.next()
 			if not self.obj and not self.data:
 				if self.nidx == self.G.edge_info[eid].src:
 					if self.G.edge_info[eid].tgt in self.touched_nodes:
 						continue
 					self.touched_nodes.add(self.G.edge_info[eid].tgt)
-				
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].tgt not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].tgt
@@ -3629,7 +3628,7 @@ cdef class NeighborIterator:
 					if self.G.edge_info[eid].src in self.touched_nodes:
 						continue
 					self.touched_nodes.add(self.G.edge_info[eid].src)
-					
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].src not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].src
@@ -3641,8 +3640,8 @@ cdef class NeighborIterator:
 				if self.nidx == self.G.edge_info[eid].src:
 					if self.G.edge_info[eid].tgt in self.touched_nodes:
 						continue
-					self.touched_nodes.add(self.G.edge_info[eid].tgt)	
-				
+					self.touched_nodes.add(self.G.edge_info[eid].tgt)
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].tgt not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].tgt
@@ -3653,7 +3652,7 @@ cdef class NeighborIterator:
 					if self.G.edge_info[eid].src in self.touched_nodes:
 						continue
 					self.touched_nodes.add(self.G.edge_info[eid].src)
-					
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].src not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].src
@@ -3665,8 +3664,8 @@ cdef class NeighborIterator:
 				if self.nidx == self.G.edge_info[eid].src:
 					if self.G.edge_info[eid].tgt in self.touched_nodes:
 						continue
-					self.touched_nodes.add(self.G.edge_info[eid].tgt)	
-				
+					self.touched_nodes.add(self.G.edge_info[eid].tgt)
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].tgt not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].tgt
@@ -3677,7 +3676,7 @@ cdef class NeighborIterator:
 					if self.G.edge_info[eid].src in self.touched_nodes:
 						continue
 					self.touched_nodes.add(self.G.edge_info[eid].src)
-					
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].src not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].src
@@ -3688,8 +3687,8 @@ cdef class NeighborIterator:
 				if self.nidx == self.G.edge_info[eid].src:
 					if self.G.edge_info[eid].tgt in self.touched_nodes:
 						continue
-					self.touched_nodes.add(self.G.edge_info[eid].tgt)	
-				
+					self.touched_nodes.add(self.G.edge_info[eid].tgt)
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].tgt not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].tgt
@@ -3700,17 +3699,17 @@ cdef class NeighborIterator:
 					if self.G.edge_info[eid].src in self.touched_nodes:
 						continue
 					self.touched_nodes.add(self.G.edge_info[eid].src)
-					
+
 					if self.use_nobjs:
 						if self.G.edge_info[eid].src not in self.G.node_obj_lookup:
 							raise ZenException, 'Node (idx=%d) does not have a node object' % self.G.edge_info[eid].src
 						return self.G.node_obj_lookup[self.G.edge_info[eid].src], self.G.node_object(self.G.edge_info[eid].src), self.G.node_data_(self.G.edge_info[eid].src)
 					else:
 						return self.G.edge_info[eid].src, self.G.node_object(self.G.edge_info[eid].src), self.G.node_data_(self.G.edge_info[eid].src)
-		
+
 	def __iter__(NeighborIterator self):
 		return self
-		
+
 cdef class SomeNeighborIterator:
 	cdef bint data
 	cdef DiGraph graph
@@ -3734,7 +3733,7 @@ cdef class SomeNeighborIterator:
 		self.neighbor_iter = None
 		self.touched_nodes = set()
 		self.use_nobjs = use_nobjs
-		
+
 		# setup the first iterator
 		if len(nbunch) > 0:
 			curr_nidx = self.nbunch_iter.next()
@@ -3745,7 +3744,7 @@ cdef class SomeNeighborIterator:
 	def __next__(SomeNeighborIterator self):
 		if self.init_num_changes != self.graph.num_changes:
 			raise GraphChangedException()
-			
+
 		while True:
 			if self.neighbor_iter is None:
 				raise StopIteration
@@ -3755,7 +3754,7 @@ cdef class SomeNeighborIterator:
 					if self.data:
 						if result[0] in self.touched_nodes:
 							continue
-						self.touched_nodes.add(result[0])	
+						self.touched_nodes.add(result[0])
 					else:
 						if result in self.touched_nodes:
 							continue

--- a/src/zen/tests/digraph.py
+++ b/src/zen/tests/digraph.py
@@ -6,133 +6,133 @@ import pickle
 from zen import *
 
 class DiGraphRelabelTestCase(unittest.TestCase):
-	
+
 	def test_change_node_obj(self):
 		G = DiGraph()
 		G.add_node(1,data=1)
 		G.set_node_object(1,2)
-		
+
 		self.assertFalse(1 in G)
 		self.assertTrue(2 in G)
-		
+
 		G.validate()
-		
+
 class DiGraphCopyTestCase(unittest.TestCase):
-	
+
 	def test_basic_index_preservation(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_edge(1,3)
 		G.rm_node(2)
-		
+
 		G2 = G.copy()
-		
+
 		self.assertEqual(G.node_idx(1),G2.node_idx(1))
 		self.assertEqual(G.node_idx(3),G2.node_idx(3))
 		self.assertEqual(G.edge_idx(1,3),G2.edge_idx(1,3))
-		
+
 		G.validate()
 		G2.validate()
 
 class DiGraphReverseTestCase(unittest.TestCase):
-	
+
 	def test_reverse(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_node(4)
-		
+
 		G = G.reverse()
-		
+
 		self.assertTrue(4 in G)
 		self.assertTrue(G.has_edge(2,1))
 		self.assertFalse(G.has_edge(1,2))
 		self.assertTrue(G.has_edge(3,2))
-		
+
 		G.validate()
-		
+
 	def test_reverse_index_preservations(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_node(3,4)
 		G.rm_node(3)
-		
+
 		G2 = G.reverse()
-		
+
 		self.assertEquals(G.node_idx(1),G2.node_idx(1))
 		self.assertEqual(G.node_idx(2),G2.node_idx(2))
 		self.assertEqual(G.edge_idx(1,2),G2.edge_idx(2,1))
-		
+
 		G.validate()
 		G2.validate()
 
 class DiGraphSkeletonTestCase(unittest.TestCase):
-	
+
 	def test_basic_node_index_preservation(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_edge(3,4)
 		G.rm_node(3)
-		
+
 		G2 = G.skeleton()
-		
+
 		self.assertEqual(G.node_idx(1),G2.node_idx(1))
 		self.assertEqual(G.node_idx(2),G2.node_idx(2))
 		self.assertEqual(G.node_idx(4),G2.node_idx(4))
-		
+
 		n1_1 = G.node_idx(1)
 		n1_2 = G2.node_idx(1)
 		n2_1 = G.node_idx(2)
 		n2_2 = G2.node_idx(2)
 		self.assertTrue(G.has_edge_(n1_2,n2_2))
-		
+
 		G.validate()
 		G2.validate()
-	
+
 	def test_basic_weight_merge(self):
 		G = DiGraph()
 		G.add_edge(1,2,weight=5)
 		G.add_edge(2,1,weight=2)
-		
+
 		avg = (5.0 + 2.0) / 2.0
-		
+
 		G1 = G.skeleton()
 		self.assertEqual(G1.weight(1,2),avg)
-		
+
 		G1.validate()
-		
+
 		G1 = G.skeleton(weight_merge_fxn=AVG_OF_WEIGHTS)
 		self.assertEqual(G1.weight(1,2),avg)
-		
+
 		G1.validate()
-		
+
 		G1 = G.skeleton(weight_merge_fxn=MIN_OF_WEIGHTS)
 		self.assertEqual(G1.weight(1,2),2)
-		
+
 		G1.validate()
-		
+
 		G1 = G.skeleton(weight_merge_fxn=MAX_OF_WEIGHTS)
 		self.assertEqual(G1.weight(1,2),5)
-		
+
 		G1.validate()
-		
+
 	def test_basic_no_none_data_merge(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=None)
 		G.add_edge(2,1,data=None)
 		G.add_edge(2,3,data=None)
 		G.add_edge(3,2,data='hi')
-		
+
 		G1 = G.skeleton()
 		self.assertEqual(G1.edge_data(1,2),None)
 		self.assertEqual(G1.edge_data(2,3),[None,'hi'])
-		
+
 		G.validate()
 		G1.validate()
-		
+
 	def test_basic_list_data_merge(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=None)
@@ -143,10 +143,10 @@ class DiGraphSkeletonTestCase(unittest.TestCase):
 		G1 = G.skeleton(LIST_OF_DATA)
 		self.assertEqual(G1.edge_data(1,2),[None,None])
 		self.assertEqual(G1.edge_data(2,3),[None,'hi'])
-		
+
 		G.validate()
 		G1.validate()
-		
+
 	def test_basic_cusotm_data_merge(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=1)
@@ -161,33 +161,33 @@ class DiGraphSkeletonTestCase(unittest.TestCase):
 				self.assertEqual(G.node_object(i),2)
 				self.assertEqual(G.node_object(j),1)
 				self.assertEqual(d2,1)
-				
+
 			return sorted([d1,d2])
 
 		G1 = G.skeleton(merge_fxn)
 		self.assertEqual(G1.edge_data(1,2),[1,2])
-		
+
 		G.validate()
 		G1.validate()
 
 class DiGraphPickleTestCase(unittest.TestCase):
-	
+
 	def test_basic(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_edge(3,1)
-		
+
 		pstr = pickle.dumps(G)
-		
+
 		G2 = pickle.loads(pstr)
 		assert G2.has_edge(1,2)
 		assert G2.has_edge(2,3)
 		assert G2.has_edge(3,1)
 		assert not G2.has_edge(1,3)
-		
+
 		G.validate()
-		
+
 	def test_removal(self):
 		G = DiGraph()
 		G.add_edge(1,2)
@@ -195,35 +195,35 @@ class DiGraphPickleTestCase(unittest.TestCase):
 		G.add_edge(3,4)
 		G.add_edge(4,5)
 		G.rm_node(3)
-		
+
 		idx2 = G.node_idx(2)
 		eidx45 = G.edge_idx(4,5)
-		
+
 		pstr = pickle.dumps(G)
-		
+
 		G2 = pickle.loads(pstr)
 		assert len(G2) == 4
 		assert G2.size() == 2
 		assert G.node_idx(2) == idx2
 		assert G.edge_idx(4,5) == eidx45
-		
+
 		# make sure things don't crash when we add a new node - are internal structures valid?
 		G2.add_edge(5,6)
-		
+
 		G.validate()
 		G2.validate()
-		
+
 class DiGraphTestCase(unittest.TestCase):
 
 	def test_out_edges_no_data(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=None)
-		
+
 		for e in G.out_edges_(G.node_idx(1),data=True):
 			pass
-			
+
 		# if we made it here, we won
-		
+
 	def test_in_edges_no_data(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=None)
@@ -232,7 +232,7 @@ class DiGraphTestCase(unittest.TestCase):
 			pass
 
 		# if we made it here, we won
-		
+
 	def test_edges_no_data(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=None)
@@ -246,12 +246,12 @@ class DiGraphTestCase(unittest.TestCase):
 		G = DiGraph()
 		G.add_edge(1,2,data=(1,2),weight=2)
 		G.add_edge(2,3,data=(2,3),weight=2)
-		
+
 		E = G.in_edges(2,weight=True)
 		e1 = E[0]
 		self.assertEquals(len(e1),3)
 		self.assertEquals(e1[2],2)
-		
+
 	def test_out_edges_weights(self):
 		G = DiGraph()
 		G.add_edge(1,2,data=(1,2),weight=2)
@@ -264,19 +264,19 @@ class DiGraphTestCase(unittest.TestCase):
 
 	def test_add_node_x_error(self):
 		G = DiGraph()
-		
+
 		# put a node into the graph
 		idx = G.add_node()
-		
+
 		# try to overwrite that node
 		try:
 			G.add_node_x(idx,G.edge_list_capacity,G.edge_list_capacity,None,None)
 			self.fail('Attempt to overwrite node using G.add_node_x succeeded')
 		except ZenException:
 			pass
-			
+
 		G.validate()
-			
+
 	def test_add_edge_x_error(self):
 		G = DiGraph()
 
@@ -290,26 +290,26 @@ class DiGraphTestCase(unittest.TestCase):
 			self.fail('Attempt to overwrite edge using G.add_edge_x succeeded')
 		except ZenException:
 			pass
-			
+
 		G.validate()
-			
+
 	def test_add_nodes(self):
 		G = DiGraph()
 		G.add_nodes(10)
-		
+
 		self.assertEquals(len(G),10)
-		
+
 		G.validate()
-		
+
 	def test_add_nodes_w_objects(self):
 		G = DiGraph()
 		G.add_nodes(10,lambda x:str(x))
-		
+
 		self.assertEquals(len(G),10)
-		
+
 		for n_,n in G.nodes_iter_(obj=True):
 			self.assertEquals(str(n_),n)
-			
+
 		G.validate()
 
 	def test_compact2(self):
@@ -318,18 +318,18 @@ class DiGraphTestCase(unittest.TestCase):
 		G.add_edge(2,1)
 		G.add_edge(1,4)
 		G.add_edge(4,4)
-		
+
 		G.rm_node(2)
-		
+
 		G.compact()
-		
+
 		self.assertEquals(G.in_degree(4),2)
 		self.assertEquals(G.out_degree(4),1)
 		self.assertTrue(G.has_edge(4,4))
 		self.assertTrue(G.has_edge(1,4))
 		self.assertEquals(G.edge_idx(4,4),0)
 		self.assertEquals(G.edge_idx(1,4),1)
-		
+
 		G.validate()
 
 	def test_compact_nodes(self):
@@ -337,13 +337,13 @@ class DiGraphTestCase(unittest.TestCase):
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.rm_node(2)
-		
+
 		self.assertEquals(G.max_node_idx,2)
 		G.compact()
 		self.assertEquals(G.max_node_idx,1)
-		
+
 		G.validate()
-		
+
 	def test_compact_edges(self):
 		G = DiGraph()
 		G.add_edge(1,2)
@@ -353,46 +353,46 @@ class DiGraphTestCase(unittest.TestCase):
 		self.assertEquals(G.max_edge_idx,1)
 		G.compact()
 		self.assertEquals(G.max_edge_idx,0)
-		
+
 		G.validate()
-		
+
 	def test_is_compact(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_edge(3,2)
-		
+
 		self.assertTrue(G.is_compact())
-		
+
 		G.rm_node(2)
-		
+
 		self.assertFalse(G.is_compact())
-		
+
 		G.add_edge(3,4)
 		G.add_edge(1,4)
-		
+
 		self.assertTrue(G.is_compact())
-		
+
 		G.add_edge(4,1)
-		
+
 		self.assertTrue(G.is_compact())
-		
+
 		G.validate()
-		
+
 	def test_selfloop(self):
 		G = DiGraph()
 		G.add_edge(1,1)
 		G.add_edge(2,2)
 		G.add_edge(3,3)
-			
+
 	def test_adj_matrix(self):
 		G = DiGraph()
 		G.add_edge(0,1)
 		G.add_edge(1,2)
 		G.add_edge(2,2)
-		
+
 		M = G.matrix()
-		
+
 		self.assertEquals(M[0,0],0)
 		self.assertEquals(M[0,1],1)
 		self.assertEquals(M[0,2],0)
@@ -402,11 +402,11 @@ class DiGraphTestCase(unittest.TestCase):
 		self.assertEquals(M[2,0],0)
 		self.assertEquals(M[2,1],0)
 		self.assertEquals(M[2,2],1)
-		
+
 		G.validate()
-		
+
 	def test_node_removal_nodes_(self):
-		
+
 		graph = DiGraph()
 		graph.add_edge(1,2)
 		graph.add_edge(3,2)
@@ -415,43 +415,43 @@ class DiGraphTestCase(unittest.TestCase):
 		nset1 = set(graph.nodes_())
 		graph.rm_node_(2)
 		nset2 = set(graph.nodes_())
-		
+
 		nset1.remove(2)
-		
+
 		self.assertTrue(4 in nset2)
 		self.assertEqual(nset1,nset2)
-		
+
 		graph.validate()
-		
+
 	def test_max_indices(self):
 		G = DiGraph()
 		n1 = G.add_node()
 		n2 = G.add_node()
 		n3 = G.add_node()
-		
+
 		G.add_edge_(n1,n2)
 		G.add_edge_(n2,n3)
-		
+
 		self.assertEqual(G.max_node_idx,2)
 		self.assertEqual(G.max_edge_idx,1)
-		
+
 		G.validate()
-		
+
 	def test_recycle_node_indices(self):
 		G = DiGraph(node_capacity=5)
 		for i in range(5):
 			G.add_node(i)
-			
+
 		for i in range(5):
 			G.rm_node(i)
-			
+
 		for i in range(5):
 			G.add_node(i)
-		
+
 		self.assertEqual(G.node_capacity,5)
-		
+
 		G.validate()
-	
+
 	def test_recycle_edge_indices(self):
 		G = DiGraph(edge_capacity=5)
 
@@ -474,85 +474,85 @@ class DiGraphTestCase(unittest.TestCase):
 		G.add_edge(1,6)
 
 		self.assertEqual(G.edge_capacity,5)
-		
+
 		G.validate()
-	
+
 	def test_basicadding(self):
 		G = DiGraph()
 		n1 = G.add_node('hello')
 		n2 = G.add_node('there')
 		n3 = G.add_node('world')
-		
+
 		self.assertEqual(len(G),3)
 		self.assertEqual(G.node_object(n1),'hello')
 		self.assertEqual(G.node_object(n2),'there')
 		self.assertEqual(G.node_object(n3),'world')
 		self.assertEqual(G.node_data_(n3),None)
-		
+
 		# add by ids
 		e1 = G.add_edge_(n1,n2)
-		
+
 		self.assertTrue(G.has_edge_(n1,n2))
 		self.assertEqual(G.edge_idx_(n1,n2),e1)
 		self.assertFalse(G.has_edge_(n1,n3))
 		self.assertEqual(G.edge_data_(e1),None)
-		
+
 		# check containment
 		self.assertTrue('hello' in G)
 		self.assertFalse('haloo' in G)
-		
+
 		# add by names
 		e2 = G.add_edge('there','world')
 		x,y = G.endpoints_(e2)
-		
+
 		self.assertEqual(x,n2)
 		self.assertEqual(y,n3)
 		self.assertTrue(G.has_edge_(n2,n3))
 		self.assertEqual(G.edge_idx_(n2,n3),e2)
 		self.assertEqual(G.edge_idx_(n2,n3),G.edge_idx('there','world'))
-		
+
 		# test degree
 		self.assertEqual(G.degree_(n1),1)
 		self.assertEqual(G.degree_(n2),2)
 		self.assertEqual(G.in_degree_(n2),1)
 		self.assertEqual(G.out_degree_(n2),1)
-		
+
 		G.validate()
-	
+
 	def test_nodes(self):
 		G = DiGraph()
 		n1 = G.add_node('hello')
 		G.add_edge('hello','there')
 		G.add_edge('there','hello')
-		
+
 		self.assertEqual(type(G.nodes()),types.ListType)
 		self.assertEqual(type(G.neighbors('hello')),types.ListType)
 		self.assertEqual(len(G.neighbors('hello')),1)
-		
+
 		G.validate()
-	
+
 	def test_nodes_(self):
 		G = DiGraph()
 		n1 = G.add_node('hello')
 		G.add_edge('hello','there')
 		G.add_edge('there','hello')
-	
+
 		self.assertEqual(len(G.neighbors_(n1)),1)
-		
+
 		G.validate()
-	
+
 	def test_edge_removal(self):
 		G = DiGraph()
 		G.add_edge(1,2)
 		G.add_edge(2,3)
 		G.add_edge(3,4)
-		
+
 		self.assertEqual(G.size(),3)
 		G.rm_edge(2,3)
 		self.assertEqual(G.size(),2)
-		
+
 		G.validate()
-	
+
 	def test_duplicate_edges(self):
 		G = DiGraph()
 		G.add_edge('1','2')
@@ -563,132 +563,132 @@ class DiGraphTestCase(unittest.TestCase):
 		except Exception,e:
 			if not str(e).startswith('Duplicate edges'):
 				self.fail('Incorrect exception: %s' % str(e))
-			
+
 		self.assertFalse(success,'This call should have thrown an exception')
-		
+
 		G.validate()
-		
+
 	def test_neighbors2(self):
 		G = DiGraph()
 		G.add_edge('hello','there')
-		
+
 		self.assertTrue('hello' in set(G.neighbors_iter('there')))
-		
+
 		G.validate()
-		
+
 	def test_small_edge_insertion(self):
 		G = DiGraph()
-		
+
 		for i in range(10):
 			G.add_node()
-		
-		order = range(10)	
+
+		order = range(10)
 		order.remove(5)
 		random.shuffle(order)
-		
+
 		for x in order:
 			G.add_edge_(5,x)
 			self.assertTrue(G.has_edge_(5,x))
-			
+
 		random.shuffle(order)
 		for x in range(10):
 			if x != 5:
 				pass
-			
+
 		random.shuffle(order)
 		for x in order:
 			G.add_edge_(x,5)
-	
+
 		for x in range(10):
 			if x != 5:
 				self.assertTrue(G.has_edge_(x,5))
-				
+
 		G.validate()
-		
+
 	def test_growing_nodearray(self):
 		G = DiGraph(node_capacity=1)
 		for i in range(10000):
 			n = G.add_node(i)
-			
+
 		G.validate()
-			
+
 	def test_growing_edgelistarray(self):
 		G = DiGraph(edge_list_capacity=1)
 		n0 = G.add_node('hello')
-	
+
 		for i in range(1000):
 			n = G.add_node(i)
 			G.add_edge_(n0,n)
 			G.add_edge_(n,n0)
-			
+
 		G.validate()
-		
+
 	def test_rm_node_edge(self):
 		G = DiGraph()
 		n1 = G.add_node()
 		n2 = G.add_node('hello')
 		n3 = G.add_node('foobar')
-		
+
 		e1 = G.add_edge_(n1,n2)
 		e2 = G.add_edge_(n2,n3)
 		e3 = G.add_edge_(n3,n1)
-		
+
 		G.rm_edge_(e3)
-		
+
 		self.assertFalse(G.has_edge_(n3,n1))
 		self.assertTrue(G.has_edge_(n1,n2))
 		self.assertTrue(G.has_edge_(n2,n3))
 		self.assertFalse(G.has_edge_(n3,n2))
-		
+
 		self.assertEqual(G.degree_(n1),1)
 		self.assertEqual(G.degree_(n2),2)
-		
+
 		G.rm_node_(n1)
-		
+
 		self.assertEqual(G.degree_(n2),1)
 		self.assertEqual(G.degree_(n3),1)
-		
+
 		G.validate()
-		
+
 	def test_node_iterator(self):
 		G = DiGraph()
 		for i in range(1000):
 			G.add_node(i)
-		
+
 		count = 0
 		for i,d in G.nodes_iter(data=True):
 			count += 1
-			
+
 		self.assertEqual(count,1000)
-		
+
 		G.validate()
-		
+
 	def test_edge_iterator(self):
 		G = DiGraph()
 		n1 = G.add_node()
 		for i in range(1000):
 			n = G.add_node()
 			G.add_edge(n1,n)
-			
+
 		count = 0
 		for x,y,d in G.edges_iter(data=True):
 			count += 1
-			
+
 		self.assertEqual(count,1000)
-		
+
 		G.validate()
-		
+
 	def test_edges(self):
 		G = DiGraph()
-		
+
 		G.add_edge('x','y')
 		E = G.edges()
 		e1 = E[0]
-		
+
 		self.assertTrue('x' in set(e1))
-		
+
 		G.validate()
-	
+
 	def test_grp_edge_iterators(self):
 		G = DiGraph()
 		n1 = G.add_node('n1')
@@ -698,18 +698,18 @@ class DiGraphTestCase(unittest.TestCase):
 			n = G.add_node(i)
 			G.add_edge_(n,n1)
 			G.add_edge_(n2,n)
-		
+
 		# test total group iterators
 		count = 0
 		for eid in G.grp_edges_iter_([n1,n2]):
 			count += 1
-		
+
 		self.assertEqual(count,21)
-		
+
 		# test the return of endpoints
 		for x,y in G.grp_in_edges_iter(['n1']):
 			self.assertEqual(y,'n1')
-		
+
 		# test the return of endpoints
 		error_thrown = False
 		try:
@@ -717,25 +717,25 @@ class DiGraphTestCase(unittest.TestCase):
 				self.assertEqual(y,'n1')
 		except:
 			error_thrown = True
-			
+
 		self.assertTrue(error_thrown)
-		
+
 		# test indegree
 		count = 0
 		for eid in G.grp_in_edges_iter_([n1,n2]):
 			count += 1
-			
+
 		self.assertEqual(count,11)
-		
+
 		# test outdegree
 		count = 0
 		for eid in G.grp_out_edges_iter_([n1,n2]):
 			count += 1
-			
+
 		self.assertEqual(count,11)
-		
+
 		G.validate()
-		
+
 	def test_grp_neighbor_iterators(self):
 		G = DiGraph()
 		n1 = G.add_node()
@@ -745,84 +745,84 @@ class DiGraphTestCase(unittest.TestCase):
 			n = G.add_node()
 			G.add_edge_(n,n1)
 			G.add_edge_(n2,n)
-	
+
 		# test total group iterators
 		count = 0
 		for eid in G.grp_neighbors_iter_([n1,n2]):
 			count += 1
-	
+
 		self.assertEqual(count,12)
-	
+
 		# test indegree
 		count = 0
 		for eid in G.grp_in_neighbors_iter_([n1,n2]):
 			count += 1
-	
+
 		self.assertEqual(count,11)
-	
+
 		# test outdegree
 		count = 0
 		for eid in G.grp_out_neighbors_iter_([n1,n2]):
 			count += 1
-	
+
 		self.assertEqual(count,11)
-		
+
 		G.validate()
-			
+
 	def test_in_edge_iterator(self):
 		G = DiGraph()
 		n1 = G.add_node()
 		for i in range(1000):
 			n = G.add_node()
 			G.add_edge_(n,n1)
-			
+
 		count = 0
 		for i,d in G.in_edges_iter_(n1,data=True):
 			count += 1
-	
+
 		self.assertEqual(count,1000)
-		
+
 		G.validate()
-		
+
 	def test_out_edge_iterator(self):
 		G = DiGraph()
 		n1 = G.add_node()
 		for i in range(1000):
 			n = G.add_node()
 			G.add_edge_(n1,n)
-			
+
 		count = 0
 		for i,d in G.out_edges_iter_(n1,data=True):
 			count += 1
-			
+
 		self.assertEqual(count,1000)
-		
+
 		G.validate()
-		
+
 	def test_neighbor_iters(self):
 		G = DiGraph()
 		n1 = G.add_node('n1')
 		n2 = G.add_node('n2')
 		n3 = G.add_node('n3')
 		n4 = G.add_node('n4')
-		
+
 		G.add_edge_(n1,n2)
 		G.add_edge_(n1,n3)
 		G.add_edge_(n4,n1)
 		G.add_edge_(n2,n1)
-		
+
 		n1_in = set(G.in_neighbors_iter_(n1))
 		n1_out = set(G.out_neighbors_iter_(n1))
 		n1_all_raw = list(G.neighbors_iter_(n1))
 		n1_all = set(n1_all_raw)
-		
+
 		self.assertEquals(n1_in,set([n4,n2]))
 		self.assertEquals(n1_out,set([n2,n3]))
 		self.assertEquals(n1_all,set([n2,n3,n4]))
 		self.assertEquals(len(n1_all_raw),3)
-		
+
 		G.validate()
-		
+
 	def test_neighbor_iter_recursionlimit(self):
 		"""
 		This tests an incorrect way that neighbor iter was implemented initially.
@@ -833,15 +833,15 @@ class DiGraphTestCase(unittest.TestCase):
 			n = G.add_node()
 			G.add_edge_(n,n1)
 			G.add_edge_(n1,n)
-			
+
 		count = 0
 		for n in G.neighbors_iter_(n1):
 			count += 1
-			
+
 		self.assertEquals(count,1100)
-		
+
 		G.validate()
-		
+
 	def test_node_iterator_with_obj_and_data(self):
 		G = DiGraph()
 		G.add_node()
@@ -851,7 +851,7 @@ class DiGraphTestCase(unittest.TestCase):
 			self.assertEqual(data,None)
 
 		G.validate()
-		
+
 	def test_edge_iterator_with_obj_and_data(self):
 		G = DiGraph()
 		G.add_edge(1,2)
@@ -859,7 +859,7 @@ class DiGraphTestCase(unittest.TestCase):
 
 		for eidx,data in G.edges_iter_(data=True):
 			self.assertEqual(data,None)
-			
+
 		G.validate()
 
 	def test_neighbor_iterator_with_obj_and_data(self):
@@ -869,7 +869,7 @@ class DiGraphTestCase(unittest.TestCase):
 
 		for x,nobj,data in G.neighbors_iter_(G.node_idx(1),obj=True,data=True):
 			self.assertEqual(data,None)
-			
+
 		G.validate()
 
 	def test_neighbor_iterator_with_data(self):
@@ -889,22 +889,22 @@ class DiGraphTestCase(unittest.TestCase):
 			self.assertTrue('does not have a node object' in str(e))
 
 		self.assertFalse(success)
-		
+
 		G.validate()
-		
+
 	def test_set_data(self):
 		G = DiGraph()
 		G.add_node(1,'hello')
 		G.add_edge(1,2,'x')
-		
+
 		G.set_node_data(1,'there')
 		G.set_edge_data(1,2,'y')
-		
+
 		self.assertEqual(G.node_data(1),'there')
 		self.assertEqual(G.edge_data(1,2),'y')
-		
+
 		G.validate()
-		
+
 	def test_weights(self):
 		G = DiGraph()
 		G.add_edge(1,2,weight=2)
@@ -913,9 +913,9 @@ class DiGraphTestCase(unittest.TestCase):
 
 		self.assertEqual(G.weight(1,2),2)
 		self.assertEqual(G.weight(1,3),5)
-		
+
 		G.validate()
-		
+
 	def test_edge_data(self):
 		G = DiGraph()
 		G.add_edge(1,2,1)
@@ -923,10 +923,10 @@ class DiGraphTestCase(unittest.TestCase):
 
 		for e,data in G.edges_(data=True):
 			pass
-			
+
 		for x,y,data in G.edges(data=True):
 			pass
-			
+
 		n1 = G.add_node()
 		n2 = G.add_node(3)
 		G.add_edge_(n1,n2)
@@ -938,11 +938,36 @@ class DiGraphTestCase(unittest.TestCase):
 		except Exception, e:
 			if str(e).startswith('Edge'):
 				success = False
-				
+
 		self.assertFalse(success)
-		
+
 		G.validate()
-		
+
+	def test_edges_nobj(self):
+		G = DiGraph()
+		G.add_edge(1,2,data='e1', weight=2)
+		G.add_edge(2,3,data='e2', weight=3)
+		G.add_edge(3,1,data='e3', weight=4)
+
+		E1 = [(1,2), (3,1)]
+		E1_data = [(1,2,'e1'), (3,1,'e3')]
+		E1_weight = [(1,2,G.weight(1,2)), (3,1,G.weight(3,1))]
+		E1_data_weight = [(1,2,'e1',G.weight(1,2)),
+						  (3,1,'e3',G.weight(3,1))]
+
+		gen_E1 = G.edges(1)
+		gen_E1_data = G.edges(1, data=True)
+		gen_E1_weight = G.edges(1, weight=True)
+		gen_E1_data_weight = G.edges(1, data=True, weight=True)
+
+		self.assertEquals(sorted(E1),sorted(gen_E1))
+		self.assertEquals(sorted(E1_data),sorted(gen_E1_data))
+		self.assertEquals(sorted(E1_weight),sorted(gen_E1_weight))
+		self.assertEquals(sorted(E1_data_weight),
+						  sorted(gen_E1_data_weight))
+
+		G.validate()
+
 	def test_modify_node_iterator(self):
 		G = DiGraph()
 		G.add_node(0)
@@ -951,14 +976,14 @@ class DiGraphTestCase(unittest.TestCase):
 			G.add_edge(i,i-1)
 
 		error = False
-		try:	
+		try:
 			for n in G.nodes_iter():
 				G.rm_node(n)
 		except GraphChangedException:
 			error = True
 
 		self.assertTrue(error)
-		
+
 		G.validate()
 
 	def test_modify_edge_iterator(self):
@@ -969,14 +994,14 @@ class DiGraphTestCase(unittest.TestCase):
 			G.add_edge(i,i-1)
 
 		error = False
-		try:	
+		try:
 			for n1,n2 in G.edges_iter():
 				G.rm_edge(n1,n2)
 		except GraphChangedException:
 			error = True
 
 		self.assertTrue(error)
-		
+
 		G.validate()
 
 	def test_modify_neighbor_iterator(self):
@@ -987,50 +1012,50 @@ class DiGraphTestCase(unittest.TestCase):
 			G.add_edge(0,i)
 
 		error = False
-		try:	
+		try:
 			for n in G.neighbors_iter(0):
 				G.rm_node(n)
 		except GraphChangedException:
 			error = True
 
 		self.assertTrue(error)
-		
+
 		G.validate()
-		
+
 	def test_invalid_nidx(self):
 		G = DiGraph()
 		n1 = G.add_node(0)
-		
+
 		error = False
 		try:
 			G.node_data_(n1+1)
 		except ZenException:
 			error = True
-			
+
 		self.assertTrue(error)
-		
+
 		G.validate()
-		
+
 	def test_edge_idx(self):
 		G = DiGraph()
 		n1 = G.add_node()
 		n2 = G.add_node()
 		e1 = G.add_edge_(n1,n2,'blah')
-		
+
 		self.assertEquals((e1,'blah'),G.edge_idx_(n1,n2,True))
-		
+
 		G.validate()
-		
+
 	def test_has_edge(self):
 		G = DiGraph()
-		
+
 		try:
 			r = G.has_edge(1,2)
 			self.assertFalse(r)
 		except:
 			self.fail('No error should be thrown')
-			
+
 		G.validate()
-			
+
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
That one caught my attention when edges_iter(nobj) and edges(nobj) weren't behaving the same way. I think it was mostly a copy-paste issue so there might be others like this around! I've added tests that failed in the previous case and now pass. 

Sorry about the deleted and added lines. I am trying to figure out where those are coming from...
