### PR TITLE
FIX: make sure zen.control gets copied to installation dir

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -50,7 +50,7 @@ setup(
 	ext_modules = ext_modules,
 	packages = ['zen','zen.data','zen.drawing','zen.generating','zen.io','zen.layout',
 				'zen.tests','zen.util','zen.algorithms.community','zen.benchmarks',
-				'zen.algorithms', 'zen.algorithms.flow'],
+				'zen.algorithms', 'zen.algorithms.flow', 'zen.control'],
 	package_data = {'zen' : ['*.pxd'],
 	'zen.algorithms' : ['*.pxd'],
 	'zen.algorithms.community' : ['*.pxd'],


### PR DESCRIPTION
Hi,

thanks a lot for sharing this code. The library looks very promising.

Please find attached a minor fix for the installation.

A small unrelated question, is there a function to generate a graph object from a numpy array directly that avoids looping over all nodes in python?

ATM I'm (mis)using the networkx function:

```
A = np.ones((10,10)
G = zen.nx.from_networkx(nx.DiGraph(A)) 
```

Best,
 Matthias
